### PR TITLE
Allow multithreaded chart loading

### DIFF
--- a/Assets/JANOARG/Resources/Meshes.meta
+++ b/Assets/JANOARG/Resources/Meshes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f6504f4fe77c312dc8ce1bad0be48460
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/JANOARG/Resources/Songs.meta
+++ b/Assets/JANOARG/Resources/Songs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 30b669f2d4566e0a5a881eed1e4fccf0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/JANOARG/Scenes/Player.unity
+++ b/Assets/JANOARG/Scenes/Player.unity
@@ -6898,8 +6898,8 @@ Camera:
   m_GameObject: {fileID: 939693536}
   m_Enabled: 0
   serializedVersion: 2
-  m_ClearFlags: 4
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0.3962264, g: 0.3962264, b: 0.3962264, a: 0}
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0
@@ -6928,7 +6928,7 @@ Camera:
   m_Depth: 0
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 1
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0

--- a/Assets/JANOARG/Scripts/Behaviors/Song Select/SongSelectReadyScreen.cs
+++ b/Assets/JANOARG/Scripts/Behaviors/Song Select/SongSelectReadyScreen.cs
@@ -58,6 +58,9 @@ public class SongSelectReadyScreen : MonoBehaviour
         CurrentProgress.text = "Please wait.";
         Bar.value = 0;
 
+        OverallProgress.color =
+            CurrentProgress.color = (Color.white - Common.main.MainCamera.backgroundColor) * new ColorFrag(a: 1);
+
         DifficultyLevelText.text = Helper.FormatDifficulty(PlayerScreen.TargetChartMeta.DifficultyLevel);
         DifficultyNameText.text = PlayerScreen.TargetChartMeta.DifficultyName.ToUpper();
         SongInfoHolder.anchoredPosition += new Vector2(1000, 0);


### PR DESCRIPTION
This should allow faster loading in especially larger charts, where it's more prone to crash/freezes if done without frame-throttling in the main thread