### PR TITLE
Rating Breakdown screenshot

### DIFF
--- a/Assets/JANOARG.Client/Resources/Prefabs/Profile/RB Entry Holder.prefab
+++ b/Assets/JANOARG.Client/Resources/Prefabs/Profile/RB Entry Holder.prefab
@@ -734,11 +734,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Rating: {fileID: 5790711041402415916}
-  Difficulty: {fileID: 5596967830407052020}
   BestScore: {fileID: 8604523014721603013}
   SongName: {fileID: 5596967829852412492}
   SongArtist: {fileID: 5596967830536910773}
-  DifficultyRating: {fileID: 5596967830407052020}
+  ChartConstant: {fileID: 5596967830407052020}
 --- !u!1 &5596967829852412850
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/JANOARG.Client/Resources/Prefabs/Profile/RB Entry Holder.prefab
+++ b/Assets/JANOARG.Client/Resources/Prefabs/Profile/RB Entry Holder.prefab
@@ -1,5 +1,96 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2654592947694407344
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5803187191550726228}
+  - component: {fileID: 1234079763363932443}
+  - component: {fileID: 531191641721545652}
+  - component: {fileID: 5432447154701177697}
+  m_Layer: 5
+  m_Name: AP Indicator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &5803187191550726228
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2654592947694407344}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1644175478488580546}
+  - {fileID: 8623256338454689005}
+  m_Father: {fileID: 5596967828796867474}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 56, y: 56}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1234079763363932443
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2654592947694407344}
+  m_CullTransparentMesh: 1
+--- !u!114 &531191641721545652
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2654592947694407344}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 6dec11b1ab9cd894099c06e3217cc901, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 0.125
+--- !u!114 &5432447154701177697
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2654592947694407344}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31a19414c41e5ae4aae2af33fee712f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowMaskGraphic: 0
 --- !u!1 &2665822712052931865
 GameObject:
   m_ObjectHideFlags: 0
@@ -158,7 +249,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 1000000<size=50%><b>ppm
+  m_text: <alpha=#40>0000000<size=50%><b>ppm
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: a45475bbff7d3214aa65958b1909c0b1, type: 2}
   m_sharedMaterial: {fileID: 5448809311310781862, guid: a45475bbff7d3214aa65958b1909c0b1, type: 2}
@@ -227,6 +318,97 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &3199319592648139360
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8623256338454689005}
+  - component: {fileID: 3630995068298733704}
+  - component: {fileID: 8288974562237351330}
+  - component: {fileID: 2535723932576296957}
+  m_Layer: 5
+  m_Name: Image 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8623256338454689005
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3199319592648139360}
+  m_LocalRotation: {x: 0, y: 0, z: 0.53729963, w: 0.8433915}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5803187191550726228}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 65}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 38, y: 38}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3630995068298733704
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3199319592648139360}
+  m_CullTransparentMesh: 1
+--- !u!114 &8288974562237351330
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3199319592648139360}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 6dec11b1ab9cd894099c06e3217cc901, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 0.5
+--- !u!114 &2535723932576296957
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3199319592648139360}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0, g: 0, b: 0, a: 0.5}
+  m_EffectDistance: {x: -0.48, y: -1.32}
+  m_UseGraphicAlpha: 1
 --- !u!1 &4047409900612230181
 GameObject:
   m_ObjectHideFlags: 0
@@ -333,8 +515,8 @@ GameObject:
   m_Component:
   - component: {fileID: 5000869515955927337}
   - component: {fileID: 7382694725024402215}
-  - component: {fileID: 5399517145894953209}
   - component: {fileID: 4416043086862842039}
+  - component: {fileID: 2845312011324422422}
   m_Layer: 5
   m_Name: Rating Info
   m_TagString: Untagged
@@ -373,36 +555,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4376397882206589961}
   m_CullTransparentMesh: 1
---- !u!114 &5399517145894953209
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4376397882206589961}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.7490196}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 34c840be3b9144144be7faf49258d0ae, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &4416043086862842039
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -418,6 +570,33 @@ MonoBehaviour:
   m_EffectColor: {r: 0, g: 0, b: 0, a: 0.5}
   m_EffectDistance: {x: 0, y: -2}
   m_UseGraphicAlpha: 1
+--- !u!114 &2845312011324422422
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4376397882206589961}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
 --- !u!1 &4820049359423087139
 GameObject:
   m_ObjectHideFlags: 0
@@ -537,7 +716,8 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 5596967830193421065}
+  - {fileID: 5803187191550726228}
+  - {fileID: 422568448675937739}
   - {fileID: 5596967828832639702}
   m_Father: {fileID: 5596967829533951124}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -594,7 +774,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5596967828832639702}
   - component: {fileID: 5596967828832639696}
-  - component: {fileID: 5596967828832639703}
+  - component: {fileID: 6778064677351753685}
   m_Layer: 5
   m_Name: Cover
   m_TagString: Untagged
@@ -629,7 +809,7 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5596967828832639701}
   m_CullTransparentMesh: 1
---- !u!114 &5596967828832639703
+--- !u!114 &6778064677351753685
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -638,27 +818,24 @@ MonoBehaviour:
   m_GameObject: {fileID: 5596967828832639701}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.15, g: 0.15, b: 0.15, a: 1}
+  m_Color: {r: 0.23584908, g: 0.23584908, b: 0.23584908, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
 --- !u!1 &5596967829533951131
 GameObject:
   m_ObjectHideFlags: 0
@@ -738,6 +915,18 @@ MonoBehaviour:
   SongName: {fileID: 5596967829852412492}
   SongArtist: {fileID: 5596967830536910773}
   ChartConstant: {fileID: 5596967830407052020}
+  Icon: {fileID: 6778064677351753685}
+  BackgroundCover: {fileID: 2845312011324422422}
+  IndicatorGraphics:
+  - {fileID: 962117387610609298}
+  - {fileID: 8288974562237351330}
+  - {fileID: 7491679565797688913}
+  - {fileID: 5596967828796867475}
+  FullStreakIndicator: {fileID: 8959675981082309327}
+  AllFlawlessIndicator: {fileID: 2654592947694407344}
+  SongInfoGraphic: {fileID: 336501056230882758}
+  SongInfoArtist: {fileID: 5596967830536910772}
+  SongInfoName: {fileID: 5596967829852412851}
 --- !u!1 &5596967829852412850
 GameObject:
   m_ObjectHideFlags: 0
@@ -803,7 +992,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Song Name
+  m_text: '-'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 3f796aa8b18de334cb25c2d1c591948a, type: 2}
   m_sharedMaterial: {fileID: -6645923801699503097, guid: 3f796aa8b18de334cb25c2d1c591948a, type: 2}
@@ -872,81 +1061,6 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!1 &5596967830193421064
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5596967830193421065}
-  - component: {fileID: 5596967830193421067}
-  - component: {fileID: 5596967830193421066}
-  m_Layer: 5
-  m_Name: Extra Indicator
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &5596967830193421065
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5596967830193421064}
-  m_LocalRotation: {x: 0, y: 0, z: 0.38268343, w: 0.92387956}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5596967828796867474}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 45}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 36, y: 36}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &5596967830193421067
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5596967830193421064}
-  m_CullTransparentMesh: 1
---- !u!114 &5596967830193421066
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5596967830193421064}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 6dec11b1ab9cd894099c06e3217cc901, type: 3}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 0.5
 --- !u!1 &5596967830407052026
 GameObject:
   m_ObjectHideFlags: 0
@@ -1012,7 +1126,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 32<sup><b>*
+  m_text: --
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: a45475bbff7d3214aa65958b1909c0b1, type: 2}
   m_sharedMaterial: {fileID: 5448809311310781862, guid: a45475bbff7d3214aa65958b1909c0b1, type: 2}
@@ -1146,7 +1260,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Song Artist
+  m_text: '-'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 3f796aa8b18de334cb25c2d1c591948a, type: 2}
   m_sharedMaterial: {fileID: -6645923801699503097, guid: 3f796aa8b18de334cb25c2d1c591948a, type: 2}
@@ -1215,6 +1329,97 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &6626330830204148097
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1644175478488580546}
+  - component: {fileID: 2241450974311935034}
+  - component: {fileID: 962117387610609298}
+  - component: {fileID: 7404608490890950126}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1644175478488580546
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6626330830204148097}
+  m_LocalRotation: {x: 0, y: 0, z: 0.2164396, w: 0.97629607}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5803187191550726228}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 25}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 38, y: 38}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2241450974311935034
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6626330830204148097}
+  m_CullTransparentMesh: 1
+--- !u!114 &962117387610609298
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6626330830204148097}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 6dec11b1ab9cd894099c06e3217cc901, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 0.5
+--- !u!114 &7404608490890950126
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6626330830204148097}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0, g: 0, b: 0, a: 0.5}
+  m_EffectDistance: {x: 0.48, y: -1.32}
+  m_UseGraphicAlpha: 1
 --- !u!1 &6884459730676114735
 GameObject:
   m_ObjectHideFlags: 0
@@ -1255,9 +1460,9 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 20, y: 105}
+  m_AnchoredPosition: {x: 20, y: 55}
   m_SizeDelta: {x: 0, y: 36}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &1810514022041132544
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1287,7 +1492,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   Slant: 15
-  ExpandStart: 0
+  ExpandStart: 1
   ExpandEnd: 1
 --- !u!114 &6593522592552721818
 MonoBehaviour:
@@ -1505,7 +1710,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 38<size=50%><b>.0
+  m_text: -<size=50%><b>
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: a45475bbff7d3214aa65958b1909c0b1, type: 2}
   m_sharedMaterial: {fileID: 5448809311310781862, guid: a45475bbff7d3214aa65958b1909c0b1, type: 2}
@@ -1574,6 +1779,97 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &7665326568903722616
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6646999397380277766}
+  - component: {fileID: 6932743553294007039}
+  - component: {fileID: 7491679565797688913}
+  - component: {fileID: 749535626989519135}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6646999397380277766
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7665326568903722616}
+  m_LocalRotation: {x: 0, y: 0, z: 0.38268343, w: 0.92387956}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 422568448675937739}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 45}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 36, y: 36}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6932743553294007039
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7665326568903722616}
+  m_CullTransparentMesh: 1
+--- !u!114 &7491679565797688913
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7665326568903722616}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 6dec11b1ab9cd894099c06e3217cc901, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 0.5
+--- !u!114 &749535626989519135
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7665326568903722616}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0, g: 0, b: 0, a: 0.5}
+  m_EffectDistance: {x: 0, y: -1.4}
+  m_UseGraphicAlpha: 1
 --- !u!1 &7788146195377380384
 GameObject:
   m_ObjectHideFlags: 0
@@ -1665,3 +1961,93 @@ MonoBehaviour:
   m_EffectColor: {r: 0, g: 0, b: 0, a: 0.5}
   m_EffectDistance: {x: 0, y: -2}
   m_UseGraphicAlpha: 1
+--- !u!1 &8959675981082309327
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 422568448675937739}
+  - component: {fileID: 2396329572126368545}
+  - component: {fileID: 4645373209125810226}
+  - component: {fileID: 7038256804926098553}
+  m_Layer: 5
+  m_Name: FC Indicator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &422568448675937739
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8959675981082309327}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6646999397380277766}
+  m_Father: {fileID: 5596967828796867474}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 56, y: 56}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2396329572126368545
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8959675981082309327}
+  m_CullTransparentMesh: 1
+--- !u!114 &4645373209125810226
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8959675981082309327}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 6dec11b1ab9cd894099c06e3217cc901, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 0.125
+--- !u!114 &7038256804926098553
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8959675981082309327}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31a19414c41e5ae4aae2af33fee712f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowMaskGraphic: 0

--- a/Assets/JANOARG.Client/Resources/Prefabs/Profile/RB Entry Holder.prefab
+++ b/Assets/JANOARG.Client/Resources/Prefabs/Profile/RB Entry Holder.prefab
@@ -34,7 +34,6 @@ RectTransform:
   - {fileID: 5596967830407052027}
   - {fileID: 1501126918497467148}
   m_Father: {fileID: 5596967829533951124}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -125,7 +124,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5000869515955927337}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -261,7 +259,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5000869515955927337}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -362,7 +359,6 @@ RectTransform:
   - {fileID: 644087618251978815}
   - {fileID: 8534863003338556936}
   m_Father: {fileID: 5596967829533951124}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -454,7 +450,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 336501056230882758}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -545,7 +540,6 @@ RectTransform:
   - {fileID: 5596967830193421065}
   - {fileID: 5596967828832639702}
   m_Father: {fileID: 5596967829533951124}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
@@ -621,7 +615,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5596967828796867474}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -677,6 +670,7 @@ GameObject:
   - component: {fileID: 5596967829533951124}
   - component: {fileID: 5596967829533951126}
   - component: {fileID: 621113464136588496}
+  - component: {fileID: 8546561980183102411}
   m_Layer: 5
   m_Name: RB Entry Holder
   m_TagString: Untagged
@@ -701,7 +695,6 @@ RectTransform:
   - {fileID: 4154325229284009706}
   - {fileID: 5596967828796867474}
   m_Father: {fileID: 0}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -728,6 +721,23 @@ CanvasGroup:
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
+--- !u!114 &8546561980183102411
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5596967829533951131}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Rating: {fileID: 5790711041402415916}
+  Difficulty: {fileID: 5596967830407052020}
+  SongName: {fileID: 5596967829852412492}
+  SongArtist: {fileID: 5596967830536910773}
+  DifficultyRating: {fileID: 5596967830407052020}
 --- !u!1 &5596967829852412850
 GameObject:
   m_ObjectHideFlags: 0
@@ -759,7 +769,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 336501056230882758}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -894,7 +903,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5596967828796867474}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 45}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -970,7 +978,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4154325229284009706}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1105,7 +1112,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 336501056230882758}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1246,7 +1252,6 @@ RectTransform:
   - {fileID: 5596967829852412851}
   - {fileID: 9212429252447764301}
   m_Father: {fileID: 5596967829533951124}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1371,7 +1376,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4154325229284009706}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -1467,7 +1471,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5000869515955927337}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -1603,7 +1606,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5000869515955927337}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}

--- a/Assets/JANOARG.Client/Resources/Prefabs/Profile/RB Entry Holder.prefab
+++ b/Assets/JANOARG.Client/Resources/Prefabs/Profile/RB Entry Holder.prefab
@@ -735,6 +735,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Rating: {fileID: 5790711041402415916}
   Difficulty: {fileID: 5596967830407052020}
+  BestScore: {fileID: 8604523014721603013}
   SongName: {fileID: 5596967829852412492}
   SongArtist: {fileID: 5596967830536910773}
   DifficultyRating: {fileID: 5596967830407052020}

--- a/Assets/JANOARG.Client/Resources/Prefabs/Profile/RB Entry Holder.prefab
+++ b/Assets/JANOARG.Client/Resources/Prefabs/Profile/RB Entry Holder.prefab
@@ -583,7 +583,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.5019608}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -924,9 +924,7 @@ MonoBehaviour:
   - {fileID: 5596967828796867475}
   FullStreakIndicator: {fileID: 8959675981082309327}
   AllFlawlessIndicator: {fileID: 2654592947694407344}
-  SongInfoGraphic: {fileID: 336501056230882758}
-  SongInfoArtist: {fileID: 5596967830536910772}
-  SongInfoName: {fileID: 5596967829852412851}
+  RatingBreakdownGroup: {fileID: 0}
 --- !u!1 &5596967829852412850
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/JANOARG.Client/Resources/Prefabs/Profile/RB Entry Holder.prefab
+++ b/Assets/JANOARG.Client/Resources/Prefabs/Profile/RB Entry Holder.prefab
@@ -907,7 +907,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 5596967829533951131}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   Rating: {fileID: 5790711041402415916}
@@ -920,11 +920,8 @@ MonoBehaviour:
   IndicatorGraphics:
   - {fileID: 962117387610609298}
   - {fileID: 8288974562237351330}
-  - {fileID: 7491679565797688913}
-  - {fileID: 5596967828796867475}
   FullStreakIndicator: {fileID: 8959675981082309327}
   AllFlawlessIndicator: {fileID: 2654592947694407344}
-  RatingBreakdownGroup: {fileID: 0}
 --- !u!1 &5596967829852412850
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/JANOARG.Client/Scenes/Panels/Profile Panel.unity
+++ b/Assets/JANOARG.Client/Scenes/Panels/Profile Panel.unity
@@ -9917,6 +9917,8 @@ GameObject:
   - component: {fileID: 1416787046}
   - component: {fileID: 1416787045}
   - component: {fileID: 1416787049}
+  - component: {fileID: 1416787051}
+  - component: {fileID: 1416787050}
   m_Layer: 6
   m_Name: Screenshot Canvas
   m_TagString: Untagged
@@ -10032,6 +10034,41 @@ MonoBehaviour:
   LevelFillGraphic: {fileID: 207893809}
   AbilityRatingLabel: {fileID: 1256289743}
   AbilityRatingText: {fileID: 427696781}
+--- !u!114 &1416787050
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1416787044}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!222 &1416787051
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1416787044}
+  m_CullTransparentMesh: 1
 --- !u!1001 &1449015748
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/JANOARG.Client/Scenes/Panels/Profile Panel.unity
+++ b/Assets/JANOARG.Client/Scenes/Panels/Profile Panel.unity
@@ -10034,7 +10034,7 @@ MonoBehaviour:
   LevelFillGraphic: {fileID: 1453021113}
   AbilityRatingLabel: {fileID: 1256289743}
   AbilityRatingText: {fileID: 427696781}
-  BestSongCover: {fileID: 0}
+  BestSongCover: {fileID: 1416787050}
   IsCoverSet: 0
 --- !u!114 &1416787050
 MonoBehaviour:

--- a/Assets/JANOARG.Client/Scenes/Panels/Profile Panel.unity
+++ b/Assets/JANOARG.Client/Scenes/Panels/Profile Panel.unity
@@ -348,6 +348,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 15224239}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &15224241 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 15224239}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &23663172
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1459,6 +1470,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 127220873}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &127220875 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 127220873}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &135084782
 GameObject:
   m_ObjectHideFlags: 0
@@ -2411,6 +2433,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 250292936}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &250292938 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 250292936}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &251885921
 GameObject:
   m_ObjectHideFlags: 0
@@ -3380,6 +3413,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 353423045}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &353423047 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 353423045}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &365801830
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3602,6 +3646,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 365801830}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &365801832 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 365801830}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &418944891 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3366629258852405542, guid: fe027bbc71a34d942a7e8b884020f928, type: 3}
@@ -3854,6 +3909,17 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 429812115}
   m_CullTransparentMesh: 1
+--- !u!114 &432695612 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 162384647}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &437081331
 GameObject:
   m_ObjectHideFlags: 0
@@ -4394,6 +4460,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 561524042}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &561524044 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 561524042}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &564194734
 GameObject:
   m_ObjectHideFlags: 0
@@ -4451,6 +4528,17 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!114 &576469294 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 525191478}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &584895073
 GameObject:
   m_ObjectHideFlags: 0
@@ -4941,6 +5029,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 637413260}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &637413262 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 637413260}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &678017183
 GameObject:
   m_ObjectHideFlags: 0
@@ -5489,6 +5588,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 713006274}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &713006276 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 713006274}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &722709780
 GameObject:
   m_ObjectHideFlags: 0
@@ -6228,6 +6338,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 791968291}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &791968293 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 791968291}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &809856993
 GameObject:
   m_ObjectHideFlags: 0
@@ -6584,6 +6705,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 811703266}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &811703268 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 811703266}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &846130898
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6810,6 +6942,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 846130898}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &846130900 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 846130898}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &881240858
 GameObject:
   m_ObjectHideFlags: 0
@@ -7121,6 +7264,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 900713943}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &900713945 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 900713943}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &902316081
 GameObject:
   m_ObjectHideFlags: 0
@@ -7928,6 +8082,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 1007164079}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1007164081 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 1007164079}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1054829994
 GameObject:
   m_ObjectHideFlags: 0
@@ -8315,6 +8480,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 1146574258}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1146574260 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 1146574258}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1154731715
 GameObject:
   m_ObjectHideFlags: 0
@@ -8703,6 +8879,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 1169366046}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1169366048 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 1169366046}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1203717516
 GameObject:
   m_ObjectHideFlags: 0
@@ -9384,6 +9571,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 1309584932}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1309584934 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 1309584932}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1323407190
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9606,6 +9804,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 1323407190}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1323407192 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 1323407190}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1356942338
 GameObject:
   m_ObjectHideFlags: 0
@@ -9707,6 +9916,7 @@ GameObject:
   - component: {fileID: 1416787047}
   - component: {fileID: 1416787046}
   - component: {fileID: 1416787045}
+  - component: {fileID: 1416787049}
   m_Layer: 6
   m_Name: Screenshot Canvas
   m_TagString: Untagged
@@ -9801,6 +10011,27 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!114 &1416787049
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1416787044}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0654f7d1079ed2a47b104c43676c4e2b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  NameLabel: {fileID: 776146775}
+  TitleLabel: {fileID: 809856995}
+  LevelLabel: {fileID: 1298824788}
+  LevelText: {fileID: 635988512}
+  LevelProgressBar: {fileID: 1453021112}
+  LevelBackgroundGraphic: {fileID: 1453021113}
+  LevelFillGraphic: {fileID: 207893809}
+  AbilityRatingLabel: {fileID: 1256289743}
+  AbilityRatingText: {fileID: 427696781}
 --- !u!1001 &1449015748
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10023,6 +10254,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 1449015748}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1449015750 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 1449015748}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1453021110
 GameObject:
   m_ObjectHideFlags: 0
@@ -11108,6 +11350,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 1554720379}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1554720381 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 1554720379}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1562277638
 GameObject:
   m_ObjectHideFlags: 0
@@ -11432,6 +11685,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 1590101885}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1590101887 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 1590101885}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1611804948
 GameObject:
   m_ObjectHideFlags: 0
@@ -11864,6 +12128,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 1675678949}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1675678951 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 1675678949}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1695471485
 GameObject:
   m_ObjectHideFlags: 0
@@ -12425,6 +12700,28 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 1743216450}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1743216452 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 1743216450}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1749304725 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 23663172}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1778686065
 GameObject:
   m_ObjectHideFlags: 0
@@ -12722,6 +13019,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 1792807414}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1792807416 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 1792807414}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1814680284
 GameObject:
   m_ObjectHideFlags: 0
@@ -12789,6 +13097,40 @@ MonoBehaviour:
   FullStreakCount: {fileID: 1882353809}
   ClearedCount: {fileID: 326979617}
   UnlockedCount: {fileID: 115380939}
+  RatingBreakdownEntries:
+  - {fileID: 5032124188025864133}
+  - {fileID: 576469294}
+  - {fileID: 2035799440}
+  - {fileID: 1749304725}
+  - {fileID: 432695612}
+  - {fileID: 1590101887}
+  - {fileID: 365801832}
+  - {fileID: 1894712420}
+  - {fileID: 250292938}
+  - {fileID: 900713945}
+  - {fileID: 1675678951}
+  - {fileID: 1146574260}
+  - {fileID: 1309584934}
+  - {fileID: 713006276}
+  - {fileID: 1449015750}
+  - {fileID: 1792807416}
+  - {fileID: 1874950797}
+  - {fileID: 1007164081}
+  - {fileID: 811703268}
+  - {fileID: 1554720381}
+  - {fileID: 1920216522}
+  - {fileID: 791968293}
+  - {fileID: 2065883278}
+  - {fileID: 127220875}
+  - {fileID: 1743216452}
+  - {fileID: 637413262}
+  - {fileID: 2029033314}
+  - {fileID: 561524044}
+  - {fileID: 1323407192}
+  - {fileID: 1169366048}
+  - {fileID: 846130900}
+  - {fileID: 353423047}
+  - {fileID: 15224241}
 --- !u!1001 &1874950795
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -13011,6 +13353,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 1874950795}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1874950797 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 1874950795}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1877837186
 GameObject:
   m_ObjectHideFlags: 0
@@ -13502,6 +13855,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 1894712418}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1894712420 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 1894712418}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1900205019
 GameObject:
   m_ObjectHideFlags: 0
@@ -14022,6 +14386,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 1920216520}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1920216522 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 1920216520}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2027936811
 GameObject:
   m_ObjectHideFlags: 0
@@ -14399,6 +14774,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 2029033312}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &2029033314 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 2029033312}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2035799438
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -14621,6 +15007,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 2035799438}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &2035799440 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 2035799438}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2043604572
 GameObject:
   m_ObjectHideFlags: 0
@@ -15074,6 +15471,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 2065883276}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &2065883278 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 2065883276}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2082124053
 GameObject:
   m_ObjectHideFlags: 0
@@ -15423,7 +15831,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5596967829533951131, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
       propertyPath: m_Name
-      value: RB Entry Holder
+      value: RB Entry Holder (0)
       objectReference: {fileID: 0}
     - target: {fileID: 5596967829533951131, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
       propertyPath: m_Layer
@@ -15631,6 +16039,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5596967829533951124, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
   m_PrefabInstance: {fileID: 610764277707946832}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &5032124188025864133 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8546561980183102411, guid: 88a7b652881d16f47b3c3c8486d515f1, type: 3}
+  m_PrefabInstance: {fileID: 610764277707946832}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/JANOARG.Client/Scenes/Panels/Profile Panel.unity
+++ b/Assets/JANOARG.Client/Scenes/Panels/Profile Panel.unity
@@ -356,7 +356,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &23663172
@@ -1478,7 +1478,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &135084782
@@ -2441,7 +2441,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &251885921
@@ -3421,7 +3421,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &365801830
@@ -3654,7 +3654,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!224 &418944891 stripped
@@ -3917,7 +3917,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &437081331
@@ -4468,7 +4468,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &564194734
@@ -4536,7 +4536,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &584895073
@@ -5037,7 +5037,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &678017183
@@ -5596,7 +5596,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &722709780
@@ -6346,7 +6346,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &809856993
@@ -6713,7 +6713,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &846130898
@@ -6950,7 +6950,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &881240858
@@ -7272,7 +7272,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &902316081
@@ -8090,7 +8090,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1054829994
@@ -8488,7 +8488,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1154731715
@@ -8887,7 +8887,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1203717516
@@ -9579,7 +9579,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &1323407190
@@ -9812,7 +9812,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1356942338
@@ -10022,7 +10022,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1416787044}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0654f7d1079ed2a47b104c43676c4e2b, type: 3}
+  m_Script: {fileID: 11500000, guid: eea2c201fa621625883dd0d35466ba98, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   NameLabel: {fileID: 776146775}
@@ -10031,10 +10031,10 @@ MonoBehaviour:
   LevelText: {fileID: 635988512}
   LevelProgressBar: {fileID: 1453021112}
   LevelBackgroundGraphic: {fileID: 1453021113}
-  LevelFillGraphic: {fileID: 207893809}
+  LevelFillGraphic: {fileID: 1453021113}
   AbilityRatingLabel: {fileID: 1256289743}
   AbilityRatingText: {fileID: 427696781}
-  BestSongCover: {fileID: 1416787050}
+  BestSongCover: {fileID: 0}
   IsCoverSet: 0
 --- !u!114 &1416787050
 MonoBehaviour:
@@ -10301,7 +10301,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1453021110
@@ -11397,7 +11397,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1562277638
@@ -11732,7 +11732,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1611804948
@@ -12175,7 +12175,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1695471485
@@ -12747,7 +12747,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &1749304725 stripped
@@ -12758,7 +12758,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1778686065
@@ -13066,7 +13066,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1814680284
@@ -13400,7 +13400,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1877837186
@@ -13902,7 +13902,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1900205019
@@ -14433,7 +14433,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &2027936811
@@ -14821,7 +14821,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &2035799438
@@ -15054,7 +15054,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &2043604572
@@ -15518,7 +15518,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &2082124053
@@ -16086,7 +16086,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4032f4bd5e5bb74b6837ad7e3684c7f0, type: 3}
+  m_Script: {fileID: 11500000, guid: 242fe95c549254b679441256c00c2122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1660057539 &9223372036854775807

--- a/Assets/JANOARG.Client/Scenes/Panels/Profile Panel.unity
+++ b/Assets/JANOARG.Client/Scenes/Panels/Profile Panel.unity
@@ -2921,8 +2921,8 @@ Camera:
   m_GameObject: {fileID: 294571163}
   m_Enabled: 1
   serializedVersion: 2
-  m_ClearFlags: 1
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 0}
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0
@@ -10034,6 +10034,8 @@ MonoBehaviour:
   LevelFillGraphic: {fileID: 207893809}
   AbilityRatingLabel: {fileID: 1256289743}
   AbilityRatingText: {fileID: 427696781}
+  BestSongCover: {fileID: 1416787050}
+  IsCoverSet: 0
 --- !u!114 &1416787050
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -10047,7 +10049,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1

--- a/Assets/JANOARG.Client/Scenes/Panels/Profile Panel.unity
+++ b/Assets/JANOARG.Client/Scenes/Panels/Profile Panel.unity
@@ -11089,7 +11089,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: "\u2630 \u2192 Profile \u2192 Ability Rating \u2192 Share\n<alpha=#77>(imagine
+  m_text: "\u2261 \u2192 Profile \u2192 Ability Rating \u2192 Share\n<alpha=#77>(imagine
     spending a subscription for this lmao)"
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 3f796aa8b18de334cb25c2d1c591948a, type: 2}

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/ProfilePanel.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/ProfilePanel.cs
@@ -161,8 +161,6 @@ namespace JANOARG.Client.Behaviors.Panels.Panel_Types
                     RatingBreakdownEntries[i].SetEntry(null);
                 }
             }
-            
-            Debug.Log("SetRatingBreakdown complete.");
         }
 
         public void ScreenshotRatingBreakdown()
@@ -173,6 +171,7 @@ namespace JANOARG.Client.Behaviors.Panels.Panel_Types
         public IEnumerator ScreenshotRatingBreakdownAnim()
         {
             isAnimating = true;
+            
             SetRatingBreakdown();
             yield return null;
             

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/ProfilePanel.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/ProfilePanel.cs
@@ -122,6 +122,7 @@ namespace JANOARG.Client.Behaviors.Panels.Profile
             return new[] { allFlawlessCount, fullStreakCount, clearedCount, unlockedCount };
         }
 
+        // Screenshot Functionality
         public Texture2D Screenshot(int width, int height)
         {
             RenderTexture rTex = new(width, height, 16, RenderTextureFormat.ARGB32);
@@ -141,7 +142,18 @@ namespace JANOARG.Client.Behaviors.Panels.Profile
             return tex2D;
         }
 
-        public void SetRatingBreakdown()
+        //Encoding of the image and saving it
+        public IEnumerator Share(Texture2D image)
+        {
+            Task task = File.WriteAllBytesAsync(
+                Application.persistentDataPath + "/screenshot.png",
+                image.EncodeToPNG());
+
+            yield return new WaitUntil(() => task.IsCompleted);
+        }
+
+        // Set Rating Breakdown Entries
+        public IEnumerator SetRatingBreakdown()
         {
             List<ScoreStoreEntry> bestEntries = StorageManager.sMain.Scores.GetBestEntries(33);
 
@@ -161,8 +173,11 @@ namespace JANOARG.Client.Behaviors.Panels.Profile
                     RatingBreakdownEntries[i].SetEntry(null);
                 }
             }
+
+            yield return null;
         }
 
+        // Screenshot Rating Breakdown button function
         public void ScreenshotRatingBreakdown()
         {
             if (!isAnimating) StartCoroutine(ScreenshotRatingBreakdownAnim());
@@ -172,7 +187,7 @@ namespace JANOARG.Client.Behaviors.Panels.Profile
         {
             isAnimating = true;
 
-            SetRatingBreakdown();
+            StartCoroutine(SetRatingBreakdown());
             yield return null;
             
             Texture2D image = Screenshot(3072, 1280);
@@ -182,13 +197,6 @@ namespace JANOARG.Client.Behaviors.Panels.Profile
             isAnimating = false;
         }
 
-        public IEnumerator Share(Texture2D image)
-        {
-            Task task = File.WriteAllBytesAsync(
-                Application.persistentDataPath + "/screenshot.png",
-                image.EncodeToPNG());
 
-            yield return new WaitUntil(() => task.IsCompleted);
-        }
     }
 }

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/ProfilePanel.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/ProfilePanel.cs
@@ -144,16 +144,9 @@ namespace JANOARG.Client.Behaviors.Panels.Panel_Types
         public void SetRatingBreakdown()
         {
             List<ScoreStoreEntry> bestEntries = StorageManager.sMain.Scores.GetBestEntries(33);
-            foreach (var entry in bestEntries)
-            {
-                Debug.Log("Best Entry: " + entry.SongID + "/" + entry.ChartID + " with rating " + entry.Rating);
-
-            }
 
             for (var i = 0; i < RatingBreakdownEntries.Length; i++)
-            {
-                Debug.Log($"Loop i={i}, bestEntries.Count={bestEntries.Count}");
-                
+            {  
                 if (i < bestEntries.Count)
                 {
                     ScoreStoreEntry entry = bestEntries[i];
@@ -164,8 +157,8 @@ namespace JANOARG.Client.Behaviors.Panels.Panel_Types
                         entry.Rating.ToString("F0"),
                         entry.ChartID,
                         entry.Score.ToString(),
-                        entry.SongID,
-                        "???",
+                        entry.SongID,   //Song Name
+                        "???",          //Song Artist
                         "23"
                     );
                 }

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/ProfilePanel.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/ProfilePanel.cs
@@ -8,6 +8,7 @@ using JANOARG.Client.Utils;
 using JANOARG.Shared.Data.ChartInfo;
 using TMPro;
 using UnityEngine;
+using UnityEngine.SocialPlatforms.Impl;
 
 namespace JANOARG.Client.Behaviors.Panels.Panel_Types
 {
@@ -27,8 +28,8 @@ namespace JANOARG.Client.Behaviors.Panels.Panel_Types
         public TMP_Text ClearedCount;
         public TMP_Text UnlockedCount;
 
+        public RatingBreakdownEntry[] RatingBreakdownEntries;
         public bool isAnimating { get; private set; }
-
         public void Awake()
         {
             Storage storage = CommonSys.sMain.Storage;
@@ -71,6 +72,7 @@ namespace JANOARG.Client.Behaviors.Panels.Panel_Types
 
             foreach (KeyValuePair<string, ScoreStoreEntry> entry in scores.entries)
             {
+                Debug.Log("Processing entry: " + entry.Key);
                 string key = entry.Key;
                 int slashIndex = key.LastIndexOf('/');
 
@@ -139,14 +141,54 @@ namespace JANOARG.Client.Behaviors.Panels.Panel_Types
             return tex2D;
         }
 
+        public void SetRatingBreakdown()
+        {
+            List<ScoreStoreEntry> bestEntries = StorageManager.sMain.Scores.GetBestEntries(33);
+            foreach (var entry in bestEntries)
+            {
+                Debug.Log("Best Entry: " + entry.SongID + "/" + entry.ChartID + " with rating " + entry.Rating);
+
+            }
+
+            for (var i = 0; i < RatingBreakdownEntries.Length; i++)
+            {
+                Debug.Log($"Loop i={i}, bestEntries.Count={bestEntries.Count}");
+                
+                if (i < bestEntries.Count)
+                {
+                    ScoreStoreEntry entry = bestEntries[i];
+
+                    Debug.Log("Setting entry " + i + " to " + entry.SongID + "/" + entry.ChartID + " with rating " + entry.Rating);
+
+                    RatingBreakdownEntries[i].SetEntry(
+                        entry.Rating.ToString("F0"),
+                        entry.ChartID,
+                        entry.Score.ToString(),
+                        entry.SongID,
+                        "???",
+                        "23"
+                    );
+                }
+                else
+                {
+                    RatingBreakdownEntries[i].SetEntry("-", "-", "-", "-", "-", "-");
+                }
+            }
+            
+            Debug.Log("SetRatingBreakdown complete.");
+        }
+
         public void ScreenshotRatingBreakdown()
         {
+            SetRatingBreakdown();
             if (!isAnimating) StartCoroutine(ScreenshotRatingBreakdownAnim());
         }
 
         public IEnumerator ScreenshotRatingBreakdownAnim()
         {
             isAnimating = true;
+
+            
             Texture2D image = Screenshot(3072, 1280);
 
             yield return Share(image);
@@ -162,5 +204,7 @@ namespace JANOARG.Client.Behaviors.Panels.Panel_Types
 
             yield return new WaitUntil(() => task.IsCompleted);
         }
+
+
     }
 }

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/ProfilePanel.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/ProfilePanel.cs
@@ -28,7 +28,7 @@ namespace JANOARG.Client.Behaviors.Panels.Panel_Types
         public TMP_Text ClearedCount;
         public TMP_Text UnlockedCount;
 
-        public RatingBreakdownEntry[] RatingBreakdownEntries;
+        private RatingBreakdownEntry[] _RatingBreakdownEntries;
         public bool isAnimating { get; private set; }
         public void Awake()
         {
@@ -145,26 +145,17 @@ namespace JANOARG.Client.Behaviors.Panels.Panel_Types
         {
             List<ScoreStoreEntry> bestEntries = StorageManager.sMain.Scores.GetBestEntries(33);
 
-            for (var i = 0; i < RatingBreakdownEntries.Length; i++)
-            {  
+            for (var i = 0; i < _RatingBreakdownEntries.Length; i++)
+            {
                 if (i < bestEntries.Count)
                 {
                     ScoreStoreEntry entry = bestEntries[i];
-
-                    Debug.Log("Setting entry " + i + " to " + entry.SongID + "/" + entry.ChartID + " with rating " + entry.Rating);
-
-                    RatingBreakdownEntries[i].SetEntry(
-                        entry.Rating.ToString("F0"),
-                        entry.ChartID,
-                        entry.Score.ToString(),
-                        entry.SongID,   //Song Name
-                        "???",          //Song Artist
-                        "23"
-                    );
+                    _RatingBreakdownEntries[i].SetEntry(entry);
+                    
                 }
                 else
                 {
-                    RatingBreakdownEntries[i].SetEntry("-", "-", "-", "-", "-", "-");
+                    _RatingBreakdownEntries[i].SetEntry(null);
                 }
             }
             

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/ProfilePanel.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/ProfilePanel.cs
@@ -10,7 +10,7 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.SocialPlatforms.Impl;
 
-namespace JANOARG.Client.Behaviors.Panels.Panel_Types
+namespace JANOARG.Client.Behaviors.Panels.Profile
 {
     public class ProfilePanel : MonoBehaviour
     {
@@ -171,7 +171,7 @@ namespace JANOARG.Client.Behaviors.Panels.Panel_Types
         public IEnumerator ScreenshotRatingBreakdownAnim()
         {
             isAnimating = true;
-            
+
             SetRatingBreakdown();
             yield return null;
             

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/ProfilePanel.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/ProfilePanel.cs
@@ -28,7 +28,7 @@ namespace JANOARG.Client.Behaviors.Panels.Panel_Types
         public TMP_Text ClearedCount;
         public TMP_Text UnlockedCount;
 
-        private RatingBreakdownEntry[] _RatingBreakdownEntries;
+        public RatingBreakdownEntry[] RatingBreakdownEntries;
         public bool isAnimating { get; private set; }
         public void Awake()
         {
@@ -145,17 +145,20 @@ namespace JANOARG.Client.Behaviors.Panels.Panel_Types
         {
             List<ScoreStoreEntry> bestEntries = StorageManager.sMain.Scores.GetBestEntries(33);
 
-            for (var i = 0; i < _RatingBreakdownEntries.Length; i++)
+            for (var i = 0; i < RatingBreakdownEntries.Length; i++)
             {
                 if (i < bestEntries.Count)
                 {
                     ScoreStoreEntry entry = bestEntries[i];
-                    _RatingBreakdownEntries[i].SetEntry(entry);
-                    
+                    StartCoroutine(RatingBreakdownEntries[i].SetEntry(entry));
+
+                    if (i == 0 ) {
+                        StartCoroutine(RatingBreakdownEntries[0].GetCoverLayer(entry));
+                    }
                 }
                 else
                 {
-                    _RatingBreakdownEntries[i].SetEntry(null);
+                    RatingBreakdownEntries[i].SetEntry(null);
                 }
             }
             
@@ -164,14 +167,14 @@ namespace JANOARG.Client.Behaviors.Panels.Panel_Types
 
         public void ScreenshotRatingBreakdown()
         {
-            SetRatingBreakdown();
             if (!isAnimating) StartCoroutine(ScreenshotRatingBreakdownAnim());
         }
 
         public IEnumerator ScreenshotRatingBreakdownAnim()
         {
             isAnimating = true;
-
+            SetRatingBreakdown();
+            yield return null;
             
             Texture2D image = Screenshot(3072, 1280);
 

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/ProfilePanel.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/ProfilePanel.cs
@@ -190,7 +190,5 @@ namespace JANOARG.Client.Behaviors.Panels.Profile
 
             yield return new WaitUntil(() => task.IsCompleted);
         }
-
-
     }
 }

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/RatingBreakdownEntry.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/RatingBreakdownEntry.cs
@@ -140,13 +140,13 @@ namespace JANOARG.Client.Behaviors.Panels.Panel_Types
 
             PlayableSong songInfo = GetSongInfo(entry.SongID);
             ExternalChartMeta chartInfo = GetSongChart(songInfo, entry.ChartID);
-            // _Color = CommonSys.sMain.Constants.GetDifficultyColor(chartInfo.DifficultyIndex);
+            _Color = CommonSys.sMain.Constants.GetDifficultyColor(chartInfo.DifficultyIndex);
 
             Rating.text = FormatRating(entry.Rating);
             BestScore.text = Helper.PadScore(entry.Score.ToString()) + "<size=50%><b>ppm";
             SongName.text = songInfo.SongName;
             SongArtist.text = songInfo.SongArtist;
-            // ChartConstant.text = Helper.FormatDifficulty(chartInfo.DifficultyLevel);
+            ChartConstant.text = Helper.FormatDifficulty(chartInfo.DifficultyLevel);
             ChartConstant.color = _Color;
 
             StartCoroutine(GetCoverImage(entry.SongID));

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/RatingBreakdownEntry.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/RatingBreakdownEntry.cs
@@ -75,15 +75,41 @@ namespace JANOARG.Client.Behaviors.Panels.Profile
             }
         }
 
-        public void SetCoverLayerColor(string songID)
+        public IEnumerator SetCoverLayerColor(string songID)
         {
             var item = GetSong(songID);
     
             //Only solid color for now since cover is using Texture
             BackgroundCover.color = item.Song.Cover.BackgroundColor;
+
+        //    foreach (CoverLayer layer in item.Song.Cover.Layers)
+        //     {
+        //         string path = Path.Combine(Path.GetDirectoryName(item.SongPath)!, layer.Target);
+        //         if (Path.HasExtension(path)) path = Path.ChangeExtension(path, "")[0..^1];
+        //         ResourceRequest request = Resources.LoadAsync<Texture2D>(path);
+
+        //         yield return new WaitUntil(() => request.isDone);
+
+        //         if (request.asset)
+        //         {
+        //             Debug.Log("Cover Layer Found: " + path);
+        //             var texture = (Texture2D)request.asset;
+        //             BackgroundCover.texture = texture;
+                    
+        //         }
+        //         else
+        //         {
+        //             Debug.Log("Cover Layer Not Found: " + path);
+        //             BackgroundCover.color = item.Song.Cover.BackgroundColor;
+        //         }
+                
+        //     }
+
+            yield return null;
+
         }
 
-        //Get Cover Layer image for the song
+        //Get Cover Layer for the Best Score
         public IEnumerator GetCoverLayer(ScoreStoreEntry entry)
         {
             var item = GetSong(entry.SongID);
@@ -106,7 +132,7 @@ namespace JANOARG.Client.Behaviors.Panels.Profile
                     Debug.Log("Cover Layer Not Found: " + path);
                     ScreenshotCanvas.sMain.SetBestSongCover(BackgroundCover.color);
                 }
-                break;
+                
             }
             if (item.Song.Cover.Layers.Count == 0)
             {
@@ -148,8 +174,7 @@ namespace JANOARG.Client.Behaviors.Panels.Profile
             ChartConstant.color = _Color;
 
             StartCoroutine(GetCoverImage(entry.SongID));
-            SetCoverLayerColor(entry.SongID);
-
+            StartCoroutine(SetCoverLayerColor(entry.SongID));
             SetIndicator(entry);
 
             yield return null;

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/RatingBreakdownEntry.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/RatingBreakdownEntry.cs
@@ -3,26 +3,52 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
+using JANOARG.Client.Behaviors.Common;
+using Unity.VisualScripting;
+using System;
 
 namespace JANOARG.Client.Behaviors.Panels.Panel_Types
 {
     public class RatingBreakdownEntry : MonoBehaviour
     {
         public TMP_Text Rating;
-        public TMP_Text Difficulty;
         public TMP_Text BestScore;
         public TMP_Text SongName;
         public TMP_Text SongArtist;
-        public TMP_Text DifficultyRating;
+        public TMP_Text ChartConstant;
 
-        public void SetEntry(string rating, string difficulty, string bestScore, string songName, string songArtist, string difficultyRating)
+        public void SetEntry(string rating, string difficulty,
+                string bestScore, string songName, string songArtist, string chartConstant)
         {
+            int diff_Index;
+            //temporary code for difficulty color 
+            switch (difficulty)
+            {
+                case "simple":
+                    diff_Index = 0;
+                    break;
+                case "normal":
+                    diff_Index = 1;
+                    break;
+                case "complex":
+                    diff_Index = 2;
+                    break;
+                case "overdrive":
+                    diff_Index = 3;
+                    break;
+                default:
+                    diff_Index = -1;
+                    break;
+            }
+
+
             Rating.text = rating + "<size=50%><b>.0";
-            Difficulty.text = difficulty;
             BestScore.text = bestScore + "<size=50%><b>ppm";
             SongName.text = songName;
             SongArtist.text = songArtist;
-            DifficultyRating.text = difficultyRating;
+            ChartConstant.text = chartConstant;
+            ChartConstant.color = CommonSys.sMain.Constants.
+                GetDifficultyColor(diff_Index);
         }
 
     }

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/RatingBreakdownEntry.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/RatingBreakdownEntry.cs
@@ -13,7 +13,7 @@ using System.IO;
 using JetBrains.Annotations;
 using JANOARG.Client.Utils;
 
-namespace JANOARG.Client.Behaviors.Panels.Panel_Types
+namespace JANOARG.Client.Behaviors.Panels.Profile
 {
     public class RatingBreakdownEntry : MonoBehaviour
     {

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/RatingBreakdownEntry.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/RatingBreakdownEntry.cs
@@ -10,20 +10,16 @@ namespace JANOARG.Client.Behaviors.Panels.Panel_Types
     {
         public TMP_Text Rating;
         public TMP_Text Difficulty;
+        public TMP_Text BestScore;
         public TMP_Text SongName;
         public TMP_Text SongArtist;
         public TMP_Text DifficultyRating;
 
-
-        public void Awake()
+        public void SetEntry(string rating, string difficulty, string bestScore, string songName, string songArtist, string difficultyRating)
         {
-            
-        }
-
-        public void SetEntry(string rating, string difficulty, string songName, string songArtist, string difficultyRating)
-        {
-            Rating.text = rating;
+            Rating.text = rating + "<size=50%><b>.0";
             Difficulty.text = difficulty;
+            BestScore.text = bestScore + "<size=50%><b>ppm";
             SongName.text = songName;
             SongArtist.text = songArtist;
             DifficultyRating.text = difficultyRating;

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/RatingBreakdownEntry.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/RatingBreakdownEntry.cs
@@ -6,6 +6,12 @@ using TMPro;
 using JANOARG.Client.Behaviors.Common;
 using Unity.VisualScripting;
 using System;
+using JANOARG.Client.Data.Storage;
+using JANOARG.Client.Behaviors.Song_Select;
+using JANOARG.Shared.Data.ChartInfo;
+using System.IO;
+using JetBrains.Annotations;
+using JANOARG.Client.Utils;
 
 namespace JANOARG.Client.Behaviors.Panels.Panel_Types
 {
@@ -17,39 +23,122 @@ namespace JANOARG.Client.Behaviors.Panels.Panel_Types
         public TMP_Text SongArtist;
         public TMP_Text ChartConstant;
 
-        public void SetEntry(string rating, string difficulty,
-                string bestScore, string songName, string songArtist, string chartConstant)
+        public RawImage Icon;
+        public RawImage BackgroundCover;
+
+        public Graphic[] IndicatorGraphics;
+        public GameObject FullStreakIndicator;
+        public GameObject AllFlawlessIndicator;
+
+        public RectTransform SongInfoGraphic;
+        public RectTransform SongInfoArtist;
+        public RectTransform SongInfoName;
+        private List<SongSelectItem> _SongSelectItems;
+        private Color _Color;
+
+        public SongSelectItem GetSong(string songID)
         {
-            int diff_Index;
-            //temporary code for difficulty color 
-            switch (difficulty)
-            {
-                case "simple":
-                    diff_Index = 0;
-                    break;
-                case "normal":
-                    diff_Index = 1;
-                    break;
-                case "complex":
-                    diff_Index = 2;
-                    break;
-                case "overdrive":
-                    diff_Index = 3;
-                    break;
-                default:
-                    diff_Index = -1;
-                    break;
-            }
+            _SongSelectItems = SongSelectScreen.sMain.itemList;
 
+            var item = _SongSelectItems.Find(x =>
+                x.Song.ClipPath.Substring(0, x.Song.ClipPath.Length - 4) == songID
+            );
 
-            Rating.text = rating + "<size=50%><b>.0";
-            BestScore.text = bestScore + "<size=50%><b>ppm";
-            SongName.text = songName;
-            SongArtist.text = songArtist;
-            ChartConstant.text = chartConstant;
-            ChartConstant.color = CommonSys.sMain.Constants.
-                GetDifficultyColor(diff_Index);
+            return item;
+        }
+        public PlayableSong GetSongInfo(string songID)
+        {
+            var item = GetSong(songID);
+            return item.Song;
         }
 
+        public ExternalChartMeta GetSongChart(PlayableSong song, string difficulty)
+        {
+            return song.Charts.Find(x => x.Target == difficulty);
+        }
+
+        public IEnumerator GetCoverImage(string songID) {
+            var item = GetSong(songID);
+
+            string path = Path.Combine(Path.GetDirectoryName(item.SongPath)!, item.Song.Cover.IconTarget);
+            if (Path.HasExtension(path)) path = Path.ChangeExtension(path, "")[0..^1];
+            ResourceRequest req = Resources.LoadAsync<Texture2D>(path);
+
+            yield return new WaitUntil(() => req.isDone);
+
+            if (req.asset)
+            {
+                var tex = (Texture2D)req.asset;
+                Icon.texture = tex;
+                Icon.color = Color.white;
+            }
+            else
+            {
+                Icon.color = item.Song.Cover.BackgroundColor;
+            }
+        }
+
+        public void GetCoverLayer(string songID)
+        {
+            var item = GetSong(songID);
+    
+            //Only solid color for now since cover is using Texture
+            BackgroundCover.color = item.Song.Cover.BackgroundColor;
+
+        }
+
+        public void SetIndicator(ScoreStoreEntry entry)
+        {
+            if (entry.BadCount == 0 & entry.GoodCount == 0)
+            {
+                AllFlawlessIndicator.SetActive(true);
+            }
+            else if (entry.BadCount == 0)
+            {
+                FullStreakIndicator.SetActive(true);
+            }
+
+            // foreach (Graphic graphic in IndicatorGraphics)
+            //     graphic.color = _Color;
+
+        }
+
+        public void SetEntry(ScoreStoreEntry entry)
+        {
+            if (entry == null)
+            {
+                return;
+            }
+
+            PlayableSong songInfo = GetSongInfo(entry.SongID);
+            ExternalChartMeta chartInfo = GetSongChart(songInfo, entry.ChartID);
+            _Color = CommonSys.sMain.Constants.GetDifficultyColor(chartInfo.DifficultyIndex);
+
+            Rating.text = FormatRating(entry.Rating);
+            BestScore.text = Helper.PadScore(entry.Score.ToString()) + "<size=50%><b>ppm";
+            SongName.text = songInfo.SongName;
+            SongArtist.text = songInfo.SongArtist;
+            ChartConstant.text = Helper.FormatDifficulty(chartInfo.DifficultyLevel);
+            ChartConstant.color = _Color;
+            
+            StartCoroutine(GetCoverImage(entry.SongID));
+            GetCoverLayer(entry.SongID);
+
+            SetIndicator(entry);
+            // StartCoroutine(AdjustSongInfoGraphic());
+
+            Debug.Log("Done");
+        }
+
+        public string FormatRating(float rating)
+        {
+            string rating_Text = rating.ToString("F1");
+
+            return rating_Text.Substring(0, rating_Text.Length - 2) +
+                    "<size=50%><b>" +
+                    rating_Text.Substring(rating_Text.Length - 2);
+        }
+
+        
     }
 }

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/RatingBreakdownEntry.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/RatingBreakdownEntry.cs
@@ -81,7 +81,6 @@ namespace JANOARG.Client.Behaviors.Panels.Profile
     
             //Only solid color for now since cover is using Texture
             BackgroundCover.color = item.Song.Cover.BackgroundColor;
-
         }
 
         public IEnumerator GetCoverLayer(ScoreStoreEntry entry)
@@ -125,10 +124,6 @@ namespace JANOARG.Client.Behaviors.Panels.Profile
             {
                 FullStreakIndicator.SetActive(true);
             }
-
-            // foreach (Graphic graphic in IndicatorGraphics)
-            //     graphic.color = _Color;
-
         }
 
         public IEnumerator SetEntry(ScoreStoreEntry entry)
@@ -165,7 +160,5 @@ namespace JANOARG.Client.Behaviors.Panels.Profile
                     "<size=50%><b>" +
                     rating_Text.Substring(rating_Text.Length - 2);
         }
-
-        
     }
 }

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/RatingBreakdownEntry.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/RatingBreakdownEntry.cs
@@ -1,0 +1,33 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+namespace JANOARG.Client.Behaviors.Panels.Panel_Types
+{
+    public class RatingBreakdownEntry : MonoBehaviour
+    {
+        public TMP_Text Rating;
+        public TMP_Text Difficulty;
+        public TMP_Text SongName;
+        public TMP_Text SongArtist;
+        public TMP_Text DifficultyRating;
+
+
+        public void Awake()
+        {
+            
+        }
+
+        public void SetEntry(string rating, string difficulty, string songName, string songArtist, string difficultyRating)
+        {
+            Rating.text = rating;
+            Difficulty.text = difficulty;
+            SongName.text = songName;
+            SongArtist.text = songArtist;
+            DifficultyRating.text = difficultyRating;
+        }
+
+    }
+}

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/RatingBreakdownEntry.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/RatingBreakdownEntry.cs
@@ -26,7 +26,6 @@ namespace JANOARG.Client.Behaviors.Panels.Profile
         public RawImage Icon;
         public RawImage BackgroundCover;
 
-        public Graphic[] IndicatorGraphics;
         public GameObject FullStreakIndicator;
         public GameObject AllFlawlessIndicator;
 
@@ -54,6 +53,7 @@ namespace JANOARG.Client.Behaviors.Panels.Profile
             return song.Charts.Find(x => x.Target == difficulty);
         }
 
+        //Get ICON image for the song
         public IEnumerator GetCoverImage(string songID) {
             var item = GetSong(songID);
 
@@ -83,6 +83,7 @@ namespace JANOARG.Client.Behaviors.Panels.Profile
             BackgroundCover.color = item.Song.Cover.BackgroundColor;
         }
 
+        //Get Cover Layer image for the song
         public IEnumerator GetCoverLayer(ScoreStoreEntry entry)
         {
             var item = GetSong(entry.SongID);
@@ -90,7 +91,7 @@ namespace JANOARG.Client.Behaviors.Panels.Profile
             foreach (CoverLayer layer in item.Song.Cover.Layers)
             {
                 string path = Path.Combine(Path.GetDirectoryName(item.SongPath)!, layer.Target);
-
+                if (Path.HasExtension(path)) path = Path.ChangeExtension(path, "")[0..^1];
                 ResourceRequest request = Resources.LoadAsync<Texture2D>(path);
 
                 yield return new WaitUntil(() => request.isDone);
@@ -102,13 +103,15 @@ namespace JANOARG.Client.Behaviors.Panels.Profile
                 }
                 else
                 {
+                    Debug.Log("Cover Layer Not Found: " + path);
                     ScreenshotCanvas.sMain.SetBestSongCover(BackgroundCover.color);
                 }
                 break;
             }
             if (item.Song.Cover.Layers.Count == 0)
             {
-                ScreenshotCanvas.sMain.SetBestSongCover(BackgroundCover.color);    
+                ScreenshotCanvas.sMain.SetBestSongCover(BackgroundCover.color);   
+                Debug.Log("No Cover Layer Found"); 
             }
             
             yield return new WaitUntil(() => ScreenshotCanvas.sMain.IsCoverSet);

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/ScreenshotCanvas.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/ScreenshotCanvas.cs
@@ -10,7 +10,6 @@ public class ScreenshotCanvas : MonoBehaviour
     public TMP_Text NameLabel;
     public TMP_Text TitleLabel;
 
-
     public TMP_Text LevelLabel;
     public TMP_Text LevelText;
   
@@ -20,6 +19,8 @@ public class ScreenshotCanvas : MonoBehaviour
 
     public TMP_Text AbilityRatingLabel;
     public TMP_Text AbilityRatingText;
+
+    
 
     private void Start()
     {

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/ScreenshotCanvas.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/ScreenshotCanvas.cs
@@ -7,12 +7,13 @@ using JANOARG.Client.Behaviors.Common;
 
 public class ScreenshotCanvas : MonoBehaviour
 {
+    public static ScreenshotCanvas sMain;
     public TMP_Text NameLabel;
     public TMP_Text TitleLabel;
 
     public TMP_Text LevelLabel;
     public TMP_Text LevelText;
-  
+
     public Slider LevelProgressBar;
     public Graphic LevelBackgroundGraphic;
     public Graphic LevelFillGraphic;
@@ -20,7 +21,13 @@ public class ScreenshotCanvas : MonoBehaviour
     public TMP_Text AbilityRatingLabel;
     public TMP_Text AbilityRatingText;
 
-    
+    public RawImage BestSongCover;
+    public bool IsCoverSet = false;
+
+    void Awake()
+    {
+        sMain = this;
+    }
 
     private void Start()
     {
@@ -38,4 +45,25 @@ public class ScreenshotCanvas : MonoBehaviour
         AbilityRatingText.text = ProfileBar.sMain.AbilityRatingText.text;
     }
 
+    public void SetBestSongCover(Texture2D texture)
+    {
+        if (IsCoverSet == false)
+        {
+            BestSongCover.texture = texture;
+            BestSongCover.color = Color.gray;
+
+            IsCoverSet = true;
+        }
+    }
+
+    public void SetBestSongCover(Color color)
+    {
+        if (IsCoverSet == false)
+        {
+            BestSongCover.color = new Color(color.r,color.g,color.b,0.75f);
+
+            IsCoverSet = true;
+        }
+    }
+    
 }

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/ScreenshotCanvas.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/ScreenshotCanvas.cs
@@ -1,0 +1,40 @@
+using System.Collections;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+using JANOARG.Client.Behaviors.Common;
+
+public class ScreenshotCanvas : MonoBehaviour
+{
+    public TMP_Text NameLabel;
+    public TMP_Text TitleLabel;
+
+
+    public TMP_Text LevelLabel;
+    public TMP_Text LevelText;
+  
+    public Slider LevelProgressBar;
+    public Graphic LevelBackgroundGraphic;
+    public Graphic LevelFillGraphic;
+
+    public TMP_Text AbilityRatingLabel;
+    public TMP_Text AbilityRatingText;
+
+    private void Start()
+    {
+        NameLabel.text = ProfileBar.sMain.NameLabel.text;
+        TitleLabel.text = ProfileBar.sMain.TitleLabel.text;
+
+        LevelLabel.text = ProfileBar.sMain.LevelLabel.text;
+        LevelText.text = ProfileBar.sMain.LevelText.text;
+
+        LevelProgressBar.value = ProfileBar.sMain.LevelProgressBar.value;
+        LevelBackgroundGraphic.color = ProfileBar.sMain.LevelBackgroundGraphic.color;
+        LevelFillGraphic.color = ProfileBar.sMain.LevelFillGraphic.color;
+
+        AbilityRatingLabel.text = ProfileBar.sMain.AbilityRatingLabel.text;
+        AbilityRatingText.text = ProfileBar.sMain.AbilityRatingText.text;
+    }
+
+}

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/ScreenshotCanvas.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/ScreenshotCanvas.cs
@@ -5,65 +5,68 @@ using UnityEngine;
 using UnityEngine.UI;
 using JANOARG.Client.Behaviors.Common;
 
-public class ScreenshotCanvas : MonoBehaviour
+namespace JANOARG.Client.Behaviors.Panels.Profile
 {
-    public static ScreenshotCanvas sMain;
-    public TMP_Text NameLabel;
-    public TMP_Text TitleLabel;
-
-    public TMP_Text LevelLabel;
-    public TMP_Text LevelText;
-
-    public Slider LevelProgressBar;
-    public Graphic LevelBackgroundGraphic;
-    public Graphic LevelFillGraphic;
-
-    public TMP_Text AbilityRatingLabel;
-    public TMP_Text AbilityRatingText;
-
-    public RawImage BestSongCover;
-    public bool IsCoverSet = false;
-
-    void Awake()
+    public class ScreenshotCanvas : MonoBehaviour
     {
-        sMain = this;
-    }
+        public static ScreenshotCanvas sMain;
+        public TMP_Text NameLabel;
+        public TMP_Text TitleLabel;
 
-    private void Start()
-    {
-        NameLabel.text = ProfileBar.sMain.NameLabel.text;
-        TitleLabel.text = ProfileBar.sMain.TitleLabel.text;
+        public TMP_Text LevelLabel;
+        public TMP_Text LevelText;
 
-        LevelLabel.text = ProfileBar.sMain.LevelLabel.text;
-        LevelText.text = ProfileBar.sMain.LevelText.text;
+        public Slider LevelProgressBar;
+        public Graphic LevelBackgroundGraphic;
+        public Graphic LevelFillGraphic;
 
-        LevelProgressBar.value = ProfileBar.sMain.LevelProgressBar.value;
-        LevelBackgroundGraphic.color = ProfileBar.sMain.LevelBackgroundGraphic.color;
-        LevelFillGraphic.color = ProfileBar.sMain.LevelFillGraphic.color;
+        public TMP_Text AbilityRatingLabel;
+        public TMP_Text AbilityRatingText;
 
-        AbilityRatingLabel.text = ProfileBar.sMain.AbilityRatingLabel.text;
-        AbilityRatingText.text = ProfileBar.sMain.AbilityRatingText.text;
-    }
+        public RawImage BestSongCover;
+        public bool IsCoverSet = false;
 
-    public void SetBestSongCover(Texture2D texture)
-    {
-        if (IsCoverSet == false)
+        void Awake()
         {
-            BestSongCover.texture = texture;
-            BestSongCover.color = Color.gray;
-
-            IsCoverSet = true;
+            sMain = this;
         }
-    }
 
-    public void SetBestSongCover(Color color)
-    {
-        if (IsCoverSet == false)
+        private void Start()
         {
-            BestSongCover.color = new Color(color.r,color.g,color.b,0.75f);
+            NameLabel.text = ProfileBar.sMain.NameLabel.text;
+            TitleLabel.text = ProfileBar.sMain.TitleLabel.text;
 
-            IsCoverSet = true;
+            LevelLabel.text = ProfileBar.sMain.LevelLabel.text;
+            LevelText.text = ProfileBar.sMain.LevelText.text;
+
+            LevelProgressBar.value = ProfileBar.sMain.LevelProgressBar.value;
+            LevelBackgroundGraphic.color = ProfileBar.sMain.LevelBackgroundGraphic.color;
+            LevelFillGraphic.color = ProfileBar.sMain.LevelFillGraphic.color;
+
+            AbilityRatingLabel.text = ProfileBar.sMain.AbilityRatingLabel.text;
+            AbilityRatingText.text = ProfileBar.sMain.AbilityRatingText.text;
         }
+
+        public void SetBestSongCover(Texture2D texture)
+        {
+            if (IsCoverSet == false)
+            {
+                BestSongCover.texture = texture;
+                BestSongCover.color = Color.gray;
+
+                IsCoverSet = true;
+            }
+        }
+
+        public void SetBestSongCover(Color color)
+        {
+            if (IsCoverSet == false)
+            {
+                BestSongCover.color = new Color(color.r, color.g, color.b, 0.75f);
+
+                IsCoverSet = true;
+            }
+        }
+
     }
-    
 }

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/ScreenshotCanvas.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel Types/ScreenshotCanvas.cs
@@ -67,6 +67,5 @@ namespace JANOARG.Client.Behaviors.Panels.Profile
                 IsCoverSet = true;
             }
         }
-
     }
 }

--- a/Assets/JANOARG.Client/Scripts/Data/Storage/ScoreStore.cs
+++ b/Assets/JANOARG.Client/Scripts/Data/Storage/ScoreStore.cs
@@ -33,6 +33,56 @@ namespace JANOARG.Client.Data.Storage
             return null;
         }
 
+        public List<ScoreStoreEntry> GetBestEntries(int count)
+        {
+            List<ScoreStoreEntry> bestEntries = new List<ScoreStoreEntry>(count);
+            float minimum_Rating = 0.00f;
+            
+            Dictionary<string, ScoreStoreEntry> entries = StorageManager.sMain.Scores.entries;
+            foreach (KeyValuePair<string, ScoreStoreEntry> entry in entries)
+            {
+                string key = entry.Key;
+                int slashIndex = key.LastIndexOf('/');
+                string songID = key.Substring(0, slashIndex);
+                string chartID = key.Substring(slashIndex + 1);
+
+                ScoreStoreEntry record = StorageManager.sMain.Scores.Get(songID, chartID);
+
+                if (record == null)
+                {
+                    Debug.LogWarning("Record of " + key + " is missing!");
+
+                    continue;
+                }
+
+                if (bestEntries.Count < count || record.Rating > minimum_Rating)
+                    {
+                        int index = bestEntries.FindIndex(e => record.Rating > e.Rating);
+
+                        if (index == -1)
+                        {
+                            bestEntries.Add(record);
+                        }
+                        else
+                        {
+                            bestEntries.Insert(index, record);
+                        }
+
+                        if (bestEntries.Count > count)
+                            bestEntries.RemoveAt(bestEntries.Count - 1);
+
+                        minimum_Rating = bestEntries[^1].Rating;
+                    }
+
+            }
+
+            bestEntries.Sort((a, b) => b.Rating.CompareTo(a.Rating)); // Sort in descending order by Rating
+
+            Debug.Log("GetBestEntries complete.");
+            Debug.Log("Best Entries Count: " + bestEntries.Count);
+            return bestEntries;
+        }
+
         public void Register(ScoreStoreEntry entry)
         {
             ScoreStoreEntry oldEntry = Get(entry.SongID, entry.ChartID);

--- a/Assets/JANOARG.Client/Scripts/Data/Storage/ScoreStore.cs
+++ b/Assets/JANOARG.Client/Scripts/Data/Storage/ScoreStore.cs
@@ -73,7 +73,6 @@ namespace JANOARG.Client.Data.Storage
 
                         minimum_Rating = bestEntries[^1].Rating;
                     }
-
             }
 
             bestEntries.Sort((a, b) => b.Rating.CompareTo(a.Rating)); // Sort in descending order by Rating


### PR DESCRIPTION
Changes:
- Changed default values of `RB Entry Holder`
- Top Bar values are now based on player save file instead of the default values.
- Rating Breakdown will now show the player's best 33 scores
- Rating Breakdown Background will based on the player's best score instead of the default skybox

Minor Issues: 
-  No \u2630 ("hamburger icon") in RobotoMono-Regular SDF so it will display white box.