### PR TITLE
Refactor animation code

### DIFF
--- a/Assets/JANOARG.Client/Scenes/Player.unity
+++ b/Assets/JANOARG.Client/Scenes/Player.unity
@@ -2476,6 +2476,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 324592700}
+  - component: {fileID: 324592701}
   m_Layer: 5
   m_Name: Judge Screen Pool
   m_TagString: Untagged
@@ -2502,6 +2503,29 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &324592701
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 324592699}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 1
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
 --- !u!1 &325656911
 GameObject:
   m_ObjectHideFlags: 0
@@ -6531,6 +6555,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 830500997}
+  - component: {fileID: 830500998}
   m_Layer: 5
   m_Name: Judge Screen
   m_TagString: Untagged
@@ -6557,6 +6582,29 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &830500998
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 830500996}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 1
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
 --- !u!1 &860655458
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Common/AudioManager.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Common/AudioManager.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using JANOARG.Shared.Data.ChartInfo;
 using UnityEngine;
 using UnityEngine.Audio;
@@ -12,7 +11,7 @@ namespace JANOARG.Client.Behaviors.Common
 
         [Space] public AudioMixer AudioMixer;
 
-        private Coroutine _SceneLowPassCutoffRoutine;
+        private EaseEnumerator _SceneLowPassCutoffRoutine;
 
         public void Awake()
         {
@@ -21,17 +20,17 @@ namespace JANOARG.Client.Behaviors.Common
 
         public void SetSceneLayerLowPassCutoff(float value, float duration)
         {
-            if (_SceneLowPassCutoffRoutine != null) StopCoroutine(_SceneLowPassCutoffRoutine);
+            _SceneLowPassCutoffRoutine?.Skip();
             _SceneLowPassCutoffRoutine = StartCoroutine(SetSceneLayerLowPassCutoffAnim(value, duration));
         }
 
-        private IEnumerator SetSceneLayerLowPassCutoffAnim(float value, float duration)
+        private EaseEnumerator SetSceneLayerLowPassCutoffAnim(float value, float duration)
         {
             AudioMixer.GetFloat("SceneLayerLowPassCutoff", out float fromLog);
             fromLog = Mathf.Log10(fromLog);
             float toLog = Mathf.Log10(value);
 
-            yield return Ease.Animate(
+            return Ease.EnumAnimate(
                 duration, a =>
                 {
                     float cutoffLog = Mathf.Lerp(fromLog, toLog, a);

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Common/AudioManager.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Common/AudioManager.cs
@@ -21,7 +21,8 @@ namespace JANOARG.Client.Behaviors.Common
         public void SetSceneLayerLowPassCutoff(float value, float duration)
         {
             _SceneLowPassCutoffRoutine?.Skip();
-            _SceneLowPassCutoffRoutine = StartCoroutine(SetSceneLayerLowPassCutoffAnim(value, duration));
+            _SceneLowPassCutoffRoutine = SetSceneLayerLowPassCutoffAnim(value, duration);
+            StartCoroutine(_SceneLowPassCutoffRoutine);
         }
 
         private EaseEnumerator SetSceneLayerLowPassCutoffAnim(float value, float duration)

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Common/LoadingBar.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Common/LoadingBar.cs
@@ -108,10 +108,9 @@ namespace JANOARG.Client.Behaviors.Common
             yield return Ease.Animate(
                 2.5f, a =>
                 {
-                    float lerp = Ease.Get(a * 3f, EaseFunction.Exponential, EaseMode.Out);
 
                     FlavorBackground.rectTransform.sizeDelta =
-                        new Vector2(FlavorBackground.rectTransform.sizeDelta.x, lerp * 100);
+                        new Vector2(FlavorBackground.rectTransform.sizeDelta.x, EaseUtils.FromZero(100, a * 3f, EaseFunction.Exponential, EaseMode.Out));
 
                     float lerp2 = Ease.Get(
                         a * 3f - 0.15f, EaseFunction.Exponential,
@@ -122,17 +121,15 @@ namespace JANOARG.Client.Behaviors.Common
                             FlavorBackground2.rectTransform.sizeDelta.x,
                             lerp2 * 100);
 
-                    float lerp3 = Ease.Get(a * 3f, EaseFunction.Exponential, EaseMode.Out);
 
                     StatusHolder.anchoredPosition = new Vector2(
                         1000 +
                         (StatusHolder.rect.width - 1000 + _Self.sizeDelta.x / -2) *
-                        (1 - lerp3), 0);
+                        EaseUtils.ToZero(1, a * 3f, EaseFunction.Exponential, EaseMode.Out), 0);
 
-                    float lerp4 = Ease.Get(a, EaseFunction.Exponential, EaseMode.Out);
 
                     FlavorText.rectTransform.anchoredPosition =
-                        new Vector2(1200 - 100 * lerp4, 0);
+                        new Vector2(1200 - EaseUtils.FromZero(100, a, EaseFunction.Exponential, EaseMode.Out), 0);
                 });
 
             IsAnimating = false;

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Common/ProfileBar.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Common/ProfileBar.cs
@@ -568,8 +568,7 @@ namespace JANOARG.Client.Behaviors.Common
 
                     SetRewardLerp(1 - lerp);
 
-                    float lerp2 = Ease.Get(x * 3 - 2, EaseFunction.Quintic, EaseMode.Out);
-                    SetChangeLerp(1 - lerp2);
+                    SetChangeLerp(EaseUtils.ToZero(1, x * 3 - 2, EaseFunction.Quintic, EaseMode.Out));
                 });
         }
 
@@ -601,10 +600,9 @@ namespace JANOARG.Client.Behaviors.Common
                         EaseMode.Out);
 
                     LevelUpLevelGraphic.rectTransform.anchorMax = new Vector2(lerp, 1);
-                    float lerp2 = Ease.Get(x, EaseFunction.Exponential, EaseMode.Out);
 
                     LevelUpLabelText.rectTransform.anchoredPosition =
-                        new Vector2(0, -50 * (1 - lerp2));
+                        new Vector2(0, -50 * EaseUtils.ToZero(1, x, EaseFunction.Exponential, EaseMode.Out));
                 });
 
             LevelText.text = level.ToString();

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Common/ProfileBar.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Common/ProfileBar.cs
@@ -374,7 +374,6 @@ namespace JANOARG.Client.Behaviors.Common
                                     });
                             StartCoroutine(coinAnim);
                         }));
-                        }));
             }
 
             // Orb particles

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Common/ProfileBar.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Common/ProfileBar.cs
@@ -343,7 +343,7 @@ namespace JANOARG.Client.Behaviors.Common
             int pCount;
 
             // Coin particles
-            Coroutine coinAnim = null;
+            EaseEnumerator coinAnim = null;
             pCount = (int)Mathf.Clamp(Mathf.Sqrt(baseCoins), 1, 15);
             List<CollectingParticle> coinParticles = new();
 
@@ -362,23 +362,23 @@ namespace JANOARG.Client.Behaviors.Common
                             CoinLabel.text = Helper.FormatCurrency(coinsOld);
                             SetRewardLerp(1);
 
-                            if (coinAnim != null)
-                                StopCoroutine(coinAnim);
+                            coinAnim?.Skip();
 
-                            coinAnim = StartCoroutine(
-                                Ease.Animate(
+                            coinAnim = Ease.EnumAnimate(
                                     .2f, x =>
                                     {
                                         CoinLabel.margin *=
                                             new Vector4Frag(y: 3 - 3 * Ease.Get(x, EaseFunction.Cubic, EaseMode.Out));
 
                                         ParticleCoinFlash.color *= new ColorFrag(a: 1 - x);
-                                    }));
+                                    });
+                            StartCoroutine(coinAnim);
+                        }));
                         }));
             }
 
             // Orb particles
-            Coroutine orbAnim = null;
+            EaseEnumerator orbAnim = null;
             pCount = (int)Mathf.Clamp(Mathf.Sqrt(baseOrbs), 1, 30);
 
             while (finalOrbs > 0)
@@ -425,22 +425,21 @@ namespace JANOARG.Client.Behaviors.Common
                         SetRewardLerp(1);
 
                         if (orbAnim != null)
-                            StopCoroutine(orbAnim);
+                            orbAnim.Skip();
 
-                        orbAnim =
-                            StartCoroutine(Ease.Animate(.2f, x =>
-                                    {
-                                        OrbLabel.margin *= new Vector4Frag(y: 3 - 3 * Ease.Get(x, EaseFunction.Cubic, EaseMode.Out));
+                        orbAnim = Ease.EnumAnimate(.2f, x =>
+                                {
+                                    OrbLabel.margin *= new Vector4Frag(y: 3 - 3 * Ease.Get(x, EaseFunction.Cubic, EaseMode.Out));
 
-                                        ParticleOrbFlash.color *= new ColorFrag(a: 1 - x);
-                                    }
-                                )
+                                    ParticleOrbFlash.color *= new ColorFrag(a: 1 - x);
+                                }
                             );
+                        StartCoroutine(orbAnim);
                     });
             }
 
             // Essence particles
-            Coroutine essenceAnim = null;
+            EaseEnumerator essenceAnim = null;
             pCount = essenceOld == totalEssence ? 0 : (int)Mathf.Clamp(essenceChange * 10, 1, 50);
 
             for (var i = 0; i < pCount; i++)
@@ -451,13 +450,13 @@ namespace JANOARG.Client.Behaviors.Common
                     AbilityRatingText.text = arOld.ToString("F2", CultureInfo.InvariantCulture);
                     EssenceLabel.text = "+" + essenceOld.ToString("F1", CultureInfo.InvariantCulture) + "%";
 
-                    if (essenceAnim != null)
-                        StopCoroutine(essenceAnim);
+                    essenceAnim?.Skip();
 
-                    essenceAnim = StartCoroutine(Ease.Animate(.2f, x =>
+                    essenceAnim = Ease.EnumAnimate(.2f, x =>
                     {
                         ParticleEssenceFlash.color *= new ColorFrag(a: 1 - x);
-                    }));
+                    });
+                    StartCoroutine(essenceAnim);
                 });
 
             _SongGainSkipLock = true;

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Common/QuickMenu.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Common/QuickMenu.cs
@@ -53,21 +53,17 @@ namespace JANOARG.Client.Behaviors.Common
                 .2f, a =>
                 {
                     ProfileBar.sMain.SetVisibility(
-                        1 -
-                        Ease.Get(
-                            a, EaseFunction.Cubic,
-                            EaseMode.Out));
-
+                        1 - Ease.Get(a, EaseFunction.Cubic, EaseMode.Out));
                     Background.alpha = a;
                 });
 
             LeftPanel.gameObject.SetActive(true);
 
             yield return Ease.Animate(
-                .2f,
+                .2f, EaseFunction.Cubic, EaseMode.Out,
                 a =>
                 {
-                    SetLeftPanelVisibility(Ease.Get(a, EaseFunction.Cubic, EaseMode.Out));
+                    SetLeftPanelVisibility(a);
                 });
 
             IsAnimating = false;
@@ -86,10 +82,10 @@ namespace JANOARG.Client.Behaviors.Common
             AudioManager.sMain.SetSceneLayerLowPassCutoff(22050, 0.5f);
 
             yield return Ease.Animate(
-                .2f,
+                .2f, EaseFunction.Cubic, EaseMode.Out,
                 a =>
                 {
-                    SetLeftPanelVisibility(1 - Ease.Get(a, EaseFunction.Cubic, EaseMode.Out));
+                    SetLeftPanelVisibility(1 - a);
                 });
 
             LeftPanel.gameObject.SetActive(false);
@@ -154,10 +150,10 @@ namespace JANOARG.Client.Behaviors.Common
             AudioManager.sMain.SetSceneLayerLowPassCutoff(9, 2);
 
             yield return Ease.Animate(
-                .2f,
+                .2f, EaseFunction.Cubic, EaseMode.Out,
                 a =>
                 {
-                    SetLeftPanelVisibility(1 - Ease.Get(a, EaseFunction.Cubic, EaseMode.Out));
+                    SetLeftPanelVisibility(1 - a);
                 });
 
             LeftPanel.gameObject.SetActive(false);

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Intro/IntroScreen.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Intro/IntroScreen.cs
@@ -258,11 +258,10 @@ namespace JANOARG.Client.Behaviors.Intro
                 TitleActionLabel.rectTransform.anchoredPosition =
                     new Vector2(TitleActionLabel.rectTransform.anchoredPosition.x, lerp2 * -36);
 
-                float lerp3 = Ease.Get(a * 1.2f - .2f, EaseFunction.Quintic, EaseMode.Out);
                 TitleFooter.alpha = (1 - Mathf.Pow(1 - Mathf.Clamp01(a * 1.2f - .2f), 2)) * .5f;
 
                 TitleFooter.rectTransform.anchoredPosition =
-                    new Vector2(TitleFooter.rectTransform.anchoredPosition.x, 80 - lerp3 * 30);
+                    new Vector2(TitleFooter.rectTransform.anchoredPosition.x, 80 - EaseUtils.FromZero(30, a * 1.2f - .2f, EaseFunction.Quintic, EaseMode.Out));
             }
 
             for (float a = 0; a < 1; a += Time.deltaTime / 2)

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Options/OptionCalibrationWizard.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Options/OptionCalibrationWizard.cs
@@ -45,7 +45,7 @@ namespace JANOARG.Client.Behaviors.Options
         public  TMP_Text    VisualOffsetInstructionLabel;
         private float       _CumulativeOffset;
 
-        private Coroutine _CurrentAnim;
+        private EaseEnumerator _CurrentAnim;
 
         private bool _IsActive;
 
@@ -125,15 +125,13 @@ namespace JANOARG.Client.Behaviors.Options
                 VisualOffsetLeft.color = VisualOffsetRight.color = new Color(1, 1, 1, 0);
             }
 
-            if (_CurrentAnim != null)
-                StopCoroutine(_CurrentAnim);
-
+            _CurrentAnim?.Skip();
             _CurrentAnim = StartCoroutine(InitializeWizardAnim());
         }
 
         public IEnumerator InitializeWizardAnim()
         {
-            yield return Ease.Animate(
+            _CurrentAnim = Ease.EnumAnimate(
                 .45f, x =>
                 {
                     float ease = Ease.Get(x * 1.5f, EaseFunction.Cubic, EaseMode.Out);
@@ -148,6 +146,7 @@ namespace JANOARG.Client.Behaviors.Options
 
                     FaderGroup.alpha = ease2;
                 });
+            yield return _CurrentAnim;
 
             _IsActive = true;
             _LastDSPTime = AudioSettings.dspTime;
@@ -169,7 +168,7 @@ namespace JANOARG.Client.Behaviors.Options
             EnhancedTouchSupport.Disable();
             InputField.onEndEdit.RemoveAllListeners();
 
-            if (_CurrentAnim != null) StopCoroutine(_CurrentAnim);
+            _CurrentAnim?.Skip();
             _CurrentAnim = StartCoroutine(HideWizardAnim());
         }
 
@@ -177,7 +176,7 @@ namespace JANOARG.Client.Behaviors.Options
         {
             CalibrationLoopPlayer.Pause();
 
-            yield return Ease.Animate(
+            _CurrentAnim = Ease.EnumAnimate(
                 .3f, x =>
                 {
                     float ease = Ease.Get(x, EaseFunction.Cubic, EaseMode.Out);
@@ -190,6 +189,7 @@ namespace JANOARG.Client.Behaviors.Options
 
                     FaderGroup.alpha = 1 - ease;
                 });
+            yield return _CurrentAnim;
 
             _CurrentAnim = null;
             JudgmentOffsetHolder.SetActive(false);

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Options/OptionCalibrationWizard.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Options/OptionCalibrationWizard.cs
@@ -126,7 +126,7 @@ namespace JANOARG.Client.Behaviors.Options
             }
 
             _CurrentAnim?.Skip();
-            _CurrentAnim = StartCoroutine(InitializeWizardAnim());
+            StartCoroutine(InitializeWizardAnim());
         }
 
         public IEnumerator InitializeWizardAnim()
@@ -169,7 +169,7 @@ namespace JANOARG.Client.Behaviors.Options
             InputField.onEndEdit.RemoveAllListeners();
 
             _CurrentAnim?.Skip();
-            _CurrentAnim = StartCoroutine(HideWizardAnim());
+            StartCoroutine(HideWizardAnim());
         }
 
         public IEnumerator HideWizardAnim()

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Options/OptionInputHandler.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Options/OptionInputHandler.cs
@@ -546,7 +546,7 @@ namespace JANOARG.Client.Behaviors.Options
                 InputBackground.rectTransform.sizeDelta = new Vector2(InputBackground.rectTransform.sizeDelta.x, ease * 40);
 
                 float ease2 = Ease.Get(x, EaseFunction.Cubic, EaseMode.Out);
-                float offset = 30 * (1 - ease2);
+                float offset = EaseUtils.ToZero(30, ease2);
                 TitleText.rectTransform.anchoredPosition = titlePos + Vector2.left * offset;
                 RightTransform.anchoredPosition = rightPos + Vector2.right * offset;
                 ListTransform.anchoredPosition = listPos + Vector2.right * offset;
@@ -591,10 +591,10 @@ namespace JANOARG.Client.Behaviors.Options
             yield return Ease.Animate(.3f, x =>
             {
                 float ease = Ease.Get(x, EaseFunction.Cubic, EaseMode.Out);
-                InputBackground.rectTransform.sizeDelta = new Vector2(InputBackground.rectTransform.sizeDelta.x, (1 - ease) * 40);
-                Background.color = new Color(0, 0, 0, .5f * (1 - ease));
+                InputBackground.rectTransform.sizeDelta = new Vector2(InputBackground.rectTransform.sizeDelta.x, EaseUtils.ToZero(40, ease));
+                Background.color = new Color(0, 0, 0, EaseUtils.ToZero(.5f, ease));
 
-                float offset = 10 * ease;
+                float offset = EaseUtils.FromZero(10, ease);
                 TitleText.rectTransform.anchoredPosition = titlePos + Vector2.left * offset;
                 RightTransform.anchoredPosition = rightPos + Vector2.right * offset;
                 ListTransform.anchoredPosition = listPos + Vector2.right * offset;
@@ -710,31 +710,28 @@ namespace JANOARG.Client.Behaviors.Options
             IsAnimating = true;
 
             if (active)
-                StartCoroutine(Ease.Animate(.4f, x =>
+                StartCoroutine(Ease.Animate(.4f, EaseFunction.Cubic, EaseMode.Out, ease =>
                 {
-                    float ease = Ease.Get(x, EaseFunction.Cubic, EaseMode.Out);
-                    AdvancedInputTransform.anchoredPosition = new Vector2(-200 - 500 * ease, AdvancedInputTransform.anchoredPosition.y);
+                    AdvancedInputTransform.anchoredPosition = new Vector2(-200 - EaseUtils.FromZero(500, ease), AdvancedInputTransform.anchoredPosition.y);
                 }));
             else
                 StartCoroutine(Ease.Animate(.5f, x =>
                 {
                     float ease2 = Ease.Get(Mathf.Clamp01(x * 1.2f - .2f), EaseFunction.Cubic, EaseMode.Out);
-                    AdvancedInputTransform.anchoredPosition = new Vector2(-700 + 500 * ease2, AdvancedInputTransform.anchoredPosition.y);
+                    AdvancedInputTransform.anchoredPosition = new Vector2(-700 + EaseUtils.FromZero(500, ease2), AdvancedInputTransform.anchoredPosition.y);
                 }));
 
-            yield return Ease.Animate(.2f, x =>
+            yield return Ease.Animate(.2f, EaseFunction.Cubic, EaseMode.Out, ease =>
             {
-                float ease = Ease.Get(x, EaseFunction.Cubic, EaseMode.Out);
-                InputHolder.sizeDelta = new Vector2(InputHolder.sizeDelta.x, -30 * ease);
-                InputGroup.alpha = (1 - ease) * (1 - ease);
+                InputHolder.sizeDelta = new Vector2(InputHolder.sizeDelta.x, EaseUtils.FromZero(-30, ease));
+                InputGroup.alpha = EaseUtils.ToZero(1, ease) * EaseUtils.ToZero(1, ease);
             });
 
             SetAdvancedInput(type, active);
 
-            yield return Ease.Animate(.4f, x =>
+            yield return Ease.Animate(.4f, EaseFunction.Cubic, EaseMode.Out, ease =>
             {
-                float ease = Ease.Get(x, EaseFunction.Cubic, EaseMode.Out);
-                InputHolder.sizeDelta = new Vector2(InputHolder.sizeDelta.x, -30 * (1 - ease));
+                InputHolder.sizeDelta = new Vector2(InputHolder.sizeDelta.x, EaseUtils.ToZero(-30, ease));
                 InputGroup.alpha = ease * ease;
             });
 

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Panels/OptionsPanel.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Panels/OptionsPanel.cs
@@ -126,16 +126,14 @@ namespace JANOARG.Client.Behaviors.Panels
                 StartCoroutine(PreviewAnim(true));
 
             yield return Ease.Animate(
-                .2f, x =>
+                .2f, EaseFunction.Cubic, EaseMode.Out, ease =>
                 {
-                    float ease = Ease.Get(x, EaseFunction.Cubic, EaseMode.Out);
-
                     TabButtons[CurrentTab]
                         .SetFill(1 - ease);
 
                     SubtitleLabel.alpha = 1 - ease;
-                    SubtitleLabel.rectTransform.anchoredPosition = Vector2.left * 10 * ease;
-                    ContentViewport.anchoredPosition = basePos + Vector2.left * 10 * ease;
+                    SubtitleLabel.rectTransform.anchoredPosition = Vector2.left * EaseUtils.FromZero(10, ease);
+                    ContentViewport.anchoredPosition = basePos + Vector2.left * EaseUtils.FromZero(10, ease);
                     ContentGroup.alpha = 1 - ease;
                 });
 
@@ -143,20 +141,18 @@ namespace JANOARG.Client.Behaviors.Panels
             CurrentTab = tab;
 
             yield return Ease.Animate(
-                .2f, x =>
+                .2f, EaseFunction.Cubic, EaseMode.Out, ease =>
                 {
-                    float ease = Ease.Get(x, EaseFunction.Cubic, EaseMode.Out);
-
                     TabButtons[CurrentTab]
                         .SetFill(ease);
 
                     SubtitleLabel.alpha = ease;
 
                     SubtitleLabel.rectTransform.anchoredPosition =
-                        Vector2.left * 10 * (1 - ease);
+                        Vector2.left * EaseUtils.ToZero(10, ease);
 
                     ContentViewport.anchoredPosition =
-                        basePos + Vector2.left * 10 * (1 - ease);
+                        basePos + Vector2.left * EaseUtils.ToZero(10, ease);
 
                     ContentGroup.alpha = ease;
                 });

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Panels/Panel.cs
@@ -42,8 +42,8 @@ namespace JANOARG.Client.Behaviors.Panels
             HolderGroup.blocksRaycasts = true;
 
             yield return Ease.Animate(
-                .2f,
-                a => { SetPanelVisibility(Ease.Get(a, EaseFunction.Cubic, EaseMode.Out)); });
+                .2f, EaseFunction.Cubic, EaseMode.Out,
+                a => { SetPanelVisibility(a); });
 
             IsAnimating = false;
         }
@@ -62,10 +62,10 @@ namespace JANOARG.Client.Behaviors.Panels
             if (sPanels.Count <= 1) AudioManager.sMain.SetSceneLayerLowPassCutoff(5000, 1f);
 
             yield return Ease.Animate(
-                .2f,
+                .2f, EaseFunction.Cubic, EaseMode.Out,
                 a =>
                 {
-                    SetPanelVisibility(1 - Ease.Get(a, EaseFunction.Cubic, EaseMode.Out));
+                    SetPanelVisibility(1 - a);
                 });
 
             CommonSys.sMain.StartCoroutine(UnloadAnim());

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Player/JudgeScreenEffect.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Player/JudgeScreenEffect.cs
@@ -49,8 +49,7 @@ namespace JANOARG.Client.Behaviors.Player
                 RingBackground.rectTransform.sizeDelta = Vector2.one * (40 + (Size * ease) + (x * 10));
                 CircleFill.rectTransform.sizeDelta = Vector2.one * (40 - (30 * ease));
 
-                float ease2 = Ease.Get(x, EaseFunction.Circle, EaseMode.In);
-                Group.alpha = 1 - ease2;
+                Group.alpha = EaseUtils.ToZero(1, x, EaseFunction.Circle, EaseMode.In);
 
                 float ease3 = ease * .96f + x * .04f;
                 RingBackground.insideRadius = RingFill1.insideRadius = RingFill2.insideRadius = ease3;

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Player/PlayerScreen.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Player/PlayerScreen.cs
@@ -21,6 +21,7 @@ namespace JANOARG.Client.Behaviors.Player
 
     public class PlayerScreen : MonoBehaviour
     {
+
         public static PlayerScreen sMain;
 
         public static string            sTargetSongPath;
@@ -175,6 +176,8 @@ namespace JANOARG.Client.Behaviors.Player
         
         internal List<int> TransparentMeshLaneIndexes = new();
         private List<LanePlayer> _LanesToRender = new();
+        
+
         public void Awake()
         {
             sMain = this;
@@ -711,6 +714,16 @@ namespace JANOARG.Client.Behaviors.Player
         {
             if (!IsPlaying)
                 return;
+            
+            #if UNITY_EDITOR
+            // Avoid stale and broken chart state when pausing in the editor, which can cause issues with testing and debugging
+                        if (EditorApplication.isPaused)
+                        {
+                            Music.Pause();
+                            _LastDSPTime = AudioSettings.dspTime;
+                            return;
+                        }
+            #endif
 
             double delta = Math.Min(AudioSettings.dspTime - _LastDSPTime, PerfectWindow);
             if (delta <= 0) delta = Time.unscaledDeltaTime;
@@ -805,7 +818,7 @@ namespace JANOARG.Client.Behaviors.Player
                 ResultExec = true;
             }
 
-            IEnumerator f_laneUpdater(float f, float visualBeat1)
+            IEnumerator f_laneUpdater(float time, float beat)
             {
                 for (int i = Lanes.Count - 1; i >= 0; i--) // Iterate backwards
                 {
@@ -813,12 +826,14 @@ namespace JANOARG.Client.Behaviors.Player
                     {
                         LanePlayer lane = Lanes[i];
 
-                        if (lane.TimeStamps[0] - 5f > f)
+                        bool hasTrivialLocalLaneMotion = f_hasTrivialLocalLaneMotion(lane);
+
+                        if (!hasTrivialLocalLaneMotion && lane.TimeStamps[0] - 5f > time)
                             continue;
 
-                        lane.UpdateSelf(f, visualBeat1);
+                        lane.UpdateSelf(time, beat);
 
-                        if (lane.MarkedForRemoval || lane == null) // Fixed logic
+                        if (lane.MarkedForRemoval || lane == null)
                         {
                             Lanes.RemoveAt(i); // More efficient than Remove()
                             Debug.Log($"[LaneRemove] Removed lane {i} from scene.");
@@ -832,6 +847,25 @@ namespace JANOARG.Client.Behaviors.Player
                 }
 
                 yield return null;
+
+                static bool f_hasTrivialLocalLaneMotion(LanePlayer lane)
+                {
+                    
+                    if (lane.Current == null) return true; // not yet initialized, don't gate it
+                    
+                    const float TRIVIAL_LANE_SPAN_THRESHOLD     = 2f;
+                    
+                    IReadOnlyList<LaneStep> laneSteps = lane.Current.LaneSteps;
+                    if (laneSteps.Count <= 1) return true;
+
+                    float span = Math.Abs(laneSteps[^1].Offset - laneSteps[0].Offset);
+                    bool hasShortSpan = span < TRIVIAL_LANE_SPAN_THRESHOLD;
+                    // TODO: Check if this operation is expensive enough to require a cached flag on load time
+                    bool isGeometryLane = laneSteps.All(s => s.Speed == 0);
+
+                    return hasShortSpan || isGeometryLane;
+                    
+                }
             }
         }
 

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Player/PlayerScreen.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Player/PlayerScreen.cs
@@ -941,12 +941,11 @@ namespace JANOARG.Client.Behaviors.Player
             yield return Ease.Animate(.6f, (x) =>
             {
                 float val = Mathf.Pow(1 - x, 5);
-                float val2 = 1 - Ease.Get(x, EaseFunction.Quintic, EaseMode.In);
 
                 ComboGroup.alpha = Combo == 0 ? 0 : val + 1;
                 ComboLabel.rectTransform.anchoredPosition *= new Vector2Frag(y: -25 + 2 * val * val);
                 JudgmentLabel.rectTransform.anchoredPosition *= new Vector2Frag(y: -25 + 2 * val * val);
-                JudgmentGroup.alpha = val2;
+                JudgmentGroup.alpha = EaseUtils.ToZero(1, x, EaseFunction.Quintic, EaseMode.In);
             });
         }
 

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Player/PlayerScreenPause.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Player/PlayerScreenPause.cs
@@ -67,14 +67,12 @@ namespace JANOARG.Client.Behaviors.Player
             UIHolder.SetActive(true);
 
             yield return Ease.Animate(
-                0.2f, x =>
+                0.2f, EaseFunction.Cubic, EaseMode.Out, ease =>
                 {
-                    float ease = Ease.Get(x, EaseFunction.Cubic, EaseMode.Out);
-
                     Background.color = CommonSys.sMain.MainCamera.backgroundColor *
                                        new Color(1, 1, 1, ease * 0.8f);
 
-                    OptionHolder.anchoredPosition = (1 - ease) * 20 * Vector2.left;
+                    OptionHolder.anchoredPosition = EaseUtils.ToZero(20, ease) * Vector2.left;
                     OptionGroup.alpha = ease;
                 });
 
@@ -92,10 +90,9 @@ namespace JANOARG.Client.Behaviors.Player
         {
             StartCoroutine(
                 Ease.Animate(
-                    0.2f, x =>
+                    0.2f, EaseFunction.Cubic, EaseMode.Out, ease =>
                     {
-                        float ease = Ease.Get(x, EaseFunction.Cubic, EaseMode.Out);
-                        OptionHolder.anchoredPosition = ease * 20 * Vector2.left;
+                        OptionHolder.anchoredPosition = EaseUtils.FromZero(20, ease) * Vector2.left;
                         OptionGroup.alpha = 1 - ease;
                     }));
 
@@ -133,10 +130,9 @@ namespace JANOARG.Client.Behaviors.Player
         {
             StartCoroutine(
                 Ease.Animate(
-                    0.2f, x =>
+                    0.2f, EaseFunction.Cubic, EaseMode.Out, ease =>
                     {
-                        float ease = Ease.Get(x, EaseFunction.Cubic, EaseMode.Out);
-                        OptionHolder.anchoredPosition = ease * 20 * Vector2.left;
+                        OptionHolder.anchoredPosition = EaseUtils.FromZero(20, ease) * Vector2.left;
                         OptionGroup.alpha = 1 - ease;
                     }));
 
@@ -159,12 +155,10 @@ namespace JANOARG.Client.Behaviors.Player
                     RetryBackground.rectTransform.sizeDelta =
                         new Vector2(0, 100 * (1 - lerp2));
 
-                    float lerp3 = Mathf.Pow(
+                    RetryFlash.color = new Color(1, 1, 1, EaseUtils.ToZero(1, Mathf.Pow(
                         Ease.Get(
                             a, EaseFunction.Exponential,
-                            EaseMode.Out), 0.5f);
-
-                    RetryFlash.color = new Color(1, 1, 1, 1 - lerp3);
+                            EaseMode.Out), 0.5f)));
                 });
 
             yield return new WaitForSeconds(1);

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Player/PlayerScreenPause.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Player/PlayerScreenPause.cs
@@ -105,10 +105,9 @@ namespace JANOARG.Client.Behaviors.Player
             yield return Ease.Animate(
                 1.5f, a =>
                 {
-                    float ease = Ease.Get(a, EaseFunction.Cubic, EaseMode.InOut);
 
                     Background.color = CommonSys.sMain.MainCamera.backgroundColor *
-                                       new Color(1, 1, 1, (1 - ease) * 0.8f);
+                                       new Color(1, 1, 1, EaseUtils.ToZero(1, a, EaseFunction.Cubic, EaseMode.InOut) * 0.8f);
 
                     PlayerScreen.sMain.Music.volume = a * targetVolume;
                 });

--- a/Assets/JANOARG.Client/Scripts/Behaviors/SongSelect/List/SongSelectFilterPanel.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/SongSelect/List/SongSelectFilterPanel.cs
@@ -56,7 +56,7 @@ namespace JANOARG.Client.Behaviors.SongSelect.List
             CurrentAnim = Ease.EnumAnimate(.3f, (t) =>
             {
                 float ease1 = Ease.Get(t, EaseFunction.Exponential, EaseMode.Out);
-                CriteriaHolder.pivot *= new Vector2Frag(y: Mathf.Lerp(startHolderPivotY, endHolderPivotY, ease1));
+                CriteriaHolder.pivot *= new Vector2Frag(y: EaseUtils.LerpTo(startHolderPivotY, endHolderPivotY, ease1));
 
                 float ease2 = Ease.Get(t * 1.5f, EaseFunction.Cubic, EaseMode.Out);
                 if (willShow) ease2 = 1 - ease2;

--- a/Assets/JANOARG.Client/Scripts/Behaviors/SongSelect/List/SongSelectFilterPanel.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/SongSelect/List/SongSelectFilterPanel.cs
@@ -47,6 +47,12 @@ namespace JANOARG.Client.Behaviors.SongSelect.List
         {
             if (SongSelectScreen.sMain.TargetSongAnim != null) return;
             IsShowing = willShow;
+
+            StartCoroutine(UpdateShowingAnim(willShow));
+        }
+
+        private IEnumerator UpdateShowingAnim(bool willShow)
+        {
             MainGroup.interactable = MainGroup.blocksRaycasts = willShow;
 
             float startHolderPivotY = CriteriaHolder.pivot.y;
@@ -62,7 +68,7 @@ namespace JANOARG.Client.Behaviors.SongSelect.List
                 if (willShow) ease2 = 1 - ease2;
                 SongSelectScreen.sMain.LerpUI(ease2);
             });
-            StartCoroutine(CurrentAnim);
+            yield return CurrentAnim;
         }
 
         public void UpdateSortCriteria()

--- a/Assets/JANOARG.Client/Scripts/Behaviors/SongSelect/List/SongSelectFilterPanel.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/SongSelect/List/SongSelectFilterPanel.cs
@@ -30,7 +30,7 @@ namespace JANOARG.Client.Behaviors.SongSelect.List
 
         public bool IsShowing { get; private set; }
 
-        Coroutine CurrentAnim;
+        EaseEnumerator CurrentAnim;
 
         public void Start()
         {
@@ -47,8 +47,22 @@ namespace JANOARG.Client.Behaviors.SongSelect.List
         {
             if (SongSelectScreen.sMain.TargetSongAnim != null) return;
             IsShowing = willShow;
-            if (CurrentAnim != null) StopCoroutine(CurrentAnim);
-            CurrentAnim = StartCoroutine(UpdateShowingAnim(willShow));
+            MainGroup.interactable = MainGroup.blocksRaycasts = willShow;
+
+            float startHolderPivotY = CriteriaHolder.pivot.y;
+            float endHolderPivotY = willShow ? 0 : 1;
+
+            CurrentAnim?.Skip();
+            CurrentAnim = Ease.EnumAnimate(.3f, (t) =>
+            {
+                float ease1 = Ease.Get(t, EaseFunction.Exponential, EaseMode.Out);
+                CriteriaHolder.pivot *= new Vector2Frag(y: Mathf.Lerp(startHolderPivotY, endHolderPivotY, ease1));
+
+                float ease2 = Ease.Get(t * 1.5f, EaseFunction.Cubic, EaseMode.Out);
+                if (willShow) ease2 = 1 - ease2;
+                SongSelectScreen.sMain.LerpUI(ease2);
+            });
+            StartCoroutine(CurrentAnim);
         }
 
         public void UpdateSortCriteria()
@@ -80,27 +94,6 @@ namespace JANOARG.Client.Behaviors.SongSelect.List
             ListView.DoSortAnim();
         }
 
-        // -------------------- Animations
-
-        public IEnumerator UpdateShowingAnim(bool willShow)
-        {
-            MainGroup.interactable = MainGroup.blocksRaycasts = willShow;
-
-            float startHolderPivotY = CriteriaHolder.pivot.y;
-            float endHolderPivotY = willShow ? 0 : 1;
-
-            yield return Ease.Animate(.3f, (t) =>
-            {
-                float ease1 = Ease.Get(t, EaseFunction.Exponential, EaseMode.Out);
-                CriteriaHolder.pivot *= new Vector2Frag(y: Mathf.Lerp(startHolderPivotY, endHolderPivotY, ease1));
-
-                float ease2 = Ease.Get(t * 1.5f, EaseFunction.Cubic, EaseMode.Out);
-                if (willShow) ease2 = 1 - ease2;
-                SongSelectScreen.sMain.LerpUI(ease2);
-            });
-
-            CurrentAnim = null;
-        }
     }
 
     public enum SongSortCriteria

--- a/Assets/JANOARG.Client/Scripts/Behaviors/SongSelect/List/SongSelectListView.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/SongSelect/List/SongSelectListView.cs
@@ -53,7 +53,7 @@ namespace JANOARG.Client.Behaviors.SongSelect.List
         public float TargetSongOffset;
         public string TargetSongID;
 
-        Coroutine currentAnim;
+        EaseEnumerator currentAnim;
 
         public void HandleUpdate()
         {
@@ -451,7 +451,7 @@ namespace JANOARG.Client.Behaviors.SongSelect.List
 
         public IEnumerator SortAnim()
         {
-            yield return Ease.Animate(.05f, (t) =>
+            yield return Ease.EnumAnimate(.05f, (t) =>
             {
                 float ease1 = t;  // Ease.Get(t, EaseFunction.Linear, EaseMode.In);
                 float xPos = 180 - 10 * ease1;
@@ -461,20 +461,21 @@ namespace JANOARG.Client.Behaviors.SongSelect.List
 
             UpdateSort();
 
-            yield return Ease.Animate(.3f, (t) =>
+            currentAnim = Ease.EnumAnimate(.3f, (t) =>
             {
                 float ease1 = Ease.Get(t, EaseFunction.Exponential, EaseMode.Out);
                 float xPos = 170 + 10 * ease1;
                 ItemGroup.alpha = ease1;
                 ItemHolder.anchoredPosition = new(xPos, ItemHolder.anchoredPosition.y);
             });
+            yield return currentAnim;
 
             currentAnim = null;
         }
 
         public void DoSortAnim()
         {
-            if (currentAnim != null) StopCoroutine(currentAnim);
+            currentAnim?.Skip();
             currentAnim = StartCoroutine(SortAnim());
         }
     }

--- a/Assets/JANOARG.Client/Scripts/Behaviors/SongSelect/List/SongSelectListView.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/SongSelect/List/SongSelectListView.cs
@@ -476,7 +476,7 @@ namespace JANOARG.Client.Behaviors.SongSelect.List
         public void DoSortAnim()
         {
             currentAnim?.Skip();
-            currentAnim = StartCoroutine(SortAnim());
+            StartCoroutine(SortAnim());
         }
     }
 }

--- a/Assets/JANOARG.Client/Scripts/Behaviors/SongSelect/Map/MapItems/SongMapItem.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/SongSelect/Map/MapItems/SongMapItem.cs
@@ -41,6 +41,7 @@ namespace JANOARG.Client.Behaviors.SongSelect.Map.MapItems
             {
                 ItemUI = MakeItemUI<SongMapItemUI, SongMapItem>();
                 MapManager.sSongMapItemUIsByID.Add(TargetID, ItemUI);
+                this.gameObject.SetActive(isRevealed); // Helps hiding decorative items alongside it
             }
         }
 

--- a/Assets/JANOARG.Client/Scripts/Behaviors/SongSelect/Map/MapManager.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/SongSelect/Map/MapManager.cs
@@ -151,6 +151,7 @@ namespace JANOARG.Client.Behaviors.SongSelect.Map
                 ProfileBar.sMain.SetVisibility(1 - t);
                 SongSelectScreen.sMain.LerpActions(1 - t);
             }));
+            yield return SongSelectScreen.sMain.LeaveInAnim(targetItem.transform);
             SongSelectScreen.sMain.MapCover.color 
                 = CommonSys.sMain.MainCamera.backgroundColor
                 = playlist.Playlist.BackgroundColor;
@@ -169,6 +170,9 @@ namespace JANOARG.Client.Behaviors.SongSelect.Map
                 ProfileBar.sMain.SetVisibility(t);
                 SongSelectScreen.sMain.LerpActions(t);
             }));
+        }
+
+        public void NavigatePreviousMap()
         {
             isReady = false;
             StartCoroutine(NavigatePreviousMapAnim());

--- a/Assets/JANOARG.Client/Scripts/Behaviors/SongSelect/Map/MapManager.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/SongSelect/Map/MapManager.cs
@@ -147,12 +147,10 @@ namespace JANOARG.Client.Behaviors.SongSelect.Map
         {
             var targetItem = sPlaylistMapItemsByID.Values.FirstOrDefault(p => p.Target == playlist);
 
-            StartCoroutine(Ease.Animate(0.3f, (t) => {
-                float lerp1 = 1 - Ease.Get(t, EaseFunction.Cubic, EaseMode.Out);
-                ProfileBar.sMain.SetVisibility(lerp1);
-                SongSelectScreen.sMain.LerpActions(lerp1);
+            StartCoroutine(Ease.Animate(0.3f, EaseFunction.Cubic, EaseMode.Out, (t) => {
+                ProfileBar.sMain.SetVisibility(1 - t);
+                SongSelectScreen.sMain.LerpActions(1 - t);
             }));
-            yield return SongSelectScreen.sMain.LeaveInAnim(targetItem.transform);
             SongSelectScreen.sMain.MapCover.color 
                 = CommonSys.sMain.MainCamera.backgroundColor
                 = playlist.Playlist.BackgroundColor;
@@ -167,14 +165,10 @@ namespace JANOARG.Client.Behaviors.SongSelect.Map
             yield return SongSelectScreen.sMain.InitPlaylist();
             yield return new WaitForSeconds(0.7f);
             SongSelectScreen.sMain.UpdateButtons();
-            StartCoroutine(Ease.Animate(0.3f, (t) => {
-                float lerp1 = Ease.Get(t, EaseFunction.Cubic, EaseMode.Out);
-                ProfileBar.sMain.SetVisibility(lerp1);
-                SongSelectScreen.sMain.LerpActions(lerp1);
+            StartCoroutine(Ease.Animate(0.3f, EaseFunction.Cubic, EaseMode.Out, (t) => {
+                ProfileBar.sMain.SetVisibility(t);
+                SongSelectScreen.sMain.LerpActions(t);
             }));
-        }
-
-        public void NavigatePreviousMap()
         {
             isReady = false;
             StartCoroutine(NavigatePreviousMapAnim());
@@ -182,10 +176,9 @@ namespace JANOARG.Client.Behaviors.SongSelect.Map
 
         public IEnumerator NavigatePreviousMapAnim()
         {
-            StartCoroutine(Ease.Animate(0.3f, (t) => {
-                float lerp1 = 1 - Ease.Get(t, EaseFunction.Cubic, EaseMode.Out);
-                ProfileBar.sMain.SetVisibility(lerp1);
-                SongSelectScreen.sMain.LerpActions(lerp1);
+            StartCoroutine(Ease.Animate(0.3f, EaseFunction.Cubic, EaseMode.Out, (t) => {
+                ProfileBar.sMain.SetVisibility(1 - t);
+                SongSelectScreen.sMain.LerpActions(1 - t);
             }));
             yield return SongSelectScreen.sMain.LeaveOutAnim();
 
@@ -200,10 +193,9 @@ namespace JANOARG.Client.Behaviors.SongSelect.Map
             yield return SongSelectScreen.sMain.InitPlaylist();
             yield return new WaitForSeconds(0.7f);
             SongSelectScreen.sMain.UpdateButtons();
-            StartCoroutine(Ease.Animate(0.3f, (t) => {
-                float lerp1 = Ease.Get(t, EaseFunction.Cubic, EaseMode.Out);
-                ProfileBar.sMain.SetVisibility(lerp1);
-                SongSelectScreen.sMain.LerpActions(lerp1);
+            StartCoroutine(Ease.Animate(0.3f, EaseFunction.Cubic, EaseMode.Out, (t) => {
+                ProfileBar.sMain.SetVisibility(t);
+                SongSelectScreen.sMain.LerpActions(t);
             }));
         }
 

--- a/Assets/JANOARG.Client/Scripts/Behaviors/SongSelect/SongSelectReadyScreen.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/SongSelect/SongSelectReadyScreen.cs
@@ -136,8 +136,7 @@ namespace JANOARG.Client.Behaviors.SongSelect
             {
                 var meshInfo = SongArtistText.textInfo.meshInfo[info.materialReferenceIndex];
                 int index = info.vertexIndex;
-                float ease = Ease.Get(x, EaseFunction.Exponential, EaseMode.In);
-                Vector3 offset = -400 * ease * new Vector3(-.26795f, -1);
+                Vector3 offset = -EaseUtils.FromZero(400, x, EaseFunction.Exponential, EaseMode.In) * new Vector3(-.26795f, -1);
                 meshInfo.vertices[index] += offset;
                 meshInfo.vertices[index + 1] += offset;
                 meshInfo.vertices[index + 2] += offset;
@@ -147,8 +146,7 @@ namespace JANOARG.Client.Behaviors.SongSelect
             {
                 var meshInfo = SongNameText.textInfo.meshInfo[info.materialReferenceIndex];
                 int index = info.vertexIndex;
-                float ease = Ease.Get(x, EaseFunction.Exponential, EaseMode.In);
-                Vector3 offset = -1000 * ease * Vector2.right;
+                Vector3 offset = -EaseUtils.FromZero(1000, x, EaseFunction.Exponential, EaseMode.In) * Vector2.right;
                 meshInfo.vertices[index] += offset;
                 meshInfo.vertices[index + 1] += offset;
                 meshInfo.vertices[index + 2] += offset;

--- a/Assets/JANOARG.Client/Scripts/Behaviors/SongSelect/SongSelectScreen.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/SongSelect/SongSelectScreen.cs
@@ -581,11 +581,10 @@ namespace JANOARG.Client.Behaviors.SongSelect
                 float lerp3 = Ease.Get(a * 3, EaseFunction.Cubic, EaseMode.Out);
                 LerpUI(lerp3);
 
-                float lerp4 = Ease.Get(a * 1.5f, EaseFunction.Circle, EaseMode.Out);
                 foreach (SongSelectListItem item in ListView.ItemList)
                 {
                     item.PositionOffset = 45 * Mathf.Clamp(item.Position - ListView.TargetSongOffset, -1, 1)
-                         * (lerp2 * .5f + lerp4 * .5f);
+                         * (lerp2 * .5f + EaseUtils.FromZero(.5f, a * 1.5f, EaseFunction.Circle, EaseMode.Out));
                 }
                 ListView.IsDirty = true;
             });
@@ -712,8 +711,7 @@ namespace JANOARG.Client.Behaviors.SongSelect
                 CommonSys.sMain.MainCamera.transform.position *= new Vector3Frag(z: -lerp3 * 2 - 10);
                 MapUIGroup.transform.localScale = Vector3.one * (1 - lerp3 * 0.1f);
 
-                float lerp4 = Ease.Get(a * 3f, EaseFunction.Exponential, EaseMode.Out);
-                LerpMapView(1 - lerp4);
+                LerpMapView(EaseUtils.ToZero(1, a * 3f, EaseFunction.Exponential, EaseMode.Out));
             });
 
             yield return navCoroutine;
@@ -982,8 +980,7 @@ namespace JANOARG.Client.Behaviors.SongSelect
                 TargetSongCoverFlash.color = new(1, 1, 1, EaseUtils.ToZero(1, lerp3));
             
 
-                float lerp4 = Ease.Get(a, EaseFunction.Cubic, EaseMode.Out);
-                float targetCameraZ = lerp4 * 5 - Mathf.Pow(lerp2, 0.75f) * 30;
+                float targetCameraZ = EaseUtils.FromZero(5, a, EaseFunction.Cubic, EaseMode.Out) - Mathf.Pow(lerp2, 0.75f) * 30;
                 CommonSys.sMain.MainCamera.transform.Translate(Vector3.back * (targetCameraZ - currentCameraZ));
                 currentCameraZ = targetCameraZ;
             });
@@ -1137,10 +1134,9 @@ namespace JANOARG.Client.Behaviors.SongSelect
 
             yield return Ease.Animate(0.6f, (t) =>
             {
-                float lerp1 = Ease.Get(t, EaseFunction.Exponential, EaseMode.In);
                 cameraTransform.position =
                     Vector3.Lerp(cameraTransform.position, target.position, 1 - Mathf.Pow(1e-3f, Time.deltaTime)) 
-                    * new Vector3Frag(z: -10 * (1 - lerp1));
+                    * new Vector3Frag(z: -10 * EaseUtils.ToZero(1, t, EaseFunction.Exponential, EaseMode.In));
                 MapCover.color *= new ColorFrag(a: Mathf.Floor(t));
 
                 if (IsMapView)

--- a/Assets/JANOARG.Client/Scripts/Behaviors/SongSelect/SongSelectScreen.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/SongSelect/SongSelectScreen.cs
@@ -348,14 +348,14 @@ namespace JANOARG.Client.Behaviors.SongSelect
                 }
                 yield return Ease.Animate(0.5f, (x) =>
                 {
-                    float ease1 = Mathf.Lerp(lerpFrom, lerpTo, Ease.Get(x, EaseFunction.Quartic, EaseMode.Out));
+                    float ease1 = EaseUtils.LerpTo(lerpFrom, lerpTo, x, EaseFunction.Quartic, EaseMode.Out);
                     foreach ((SongMapItemUI mapItem, SongSelectListSongUI listItem) in mapListItems)
                     {
                         mapItem.UpdatePosition();
                         mapItem.transform.position = Vector3.Lerp(mapItem.transform.position, listItem.CoverImage.transform.position, ease1);
                     }
                 
-                    float ease2 = Mathf.Lerp(lerpFrom, lerpTo, Ease.Get(x, EaseFunction.Quadratic, EaseMode.InOut));
+                    float ease2 = EaseUtils.LerpTo(lerpFrom, lerpTo, x, EaseFunction.Quadratic, EaseMode.InOut);
                     CommonSys.sMain.MainCamera.transform.position *= new Vector3Frag(z: -ease2 * 2 - 10);
                 });
                 foreach ((SongMapItemUI mapItem, SongSelectListSongUI listItem) in mapListItems)
@@ -399,9 +399,8 @@ namespace JANOARG.Client.Behaviors.SongSelect
                 mapCoroutine = StartCoroutine(MapCoroutine());
 
                 // Animate
-                yield return Ease.Animate(0.3f, (x) =>
+                yield return Ease.Animate(0.3f, EaseFunction.Cubic, EaseMode.Out, ease1 =>
                 {
-                    float ease1 = Ease.Get(x, EaseFunction.Cubic, EaseMode.Out);
                     LerpMapView(ease1);
                     ListView.LerpListView(1 - ease1);
                     if (IsTargetSongUnlocked)
@@ -777,16 +776,15 @@ namespace JANOARG.Client.Behaviors.SongSelect
                 SongBurstMainImage.rectTransform.position = center.position;
 
                 float ease1 = Ease.Get(t, EaseFunction.Cubic, EaseMode.Out);
-                SongBurstMainImage.rectTransform.sizeDelta = Vector2.one * (40 + 80 * ease1);
+                SongBurstMainImage.rectTransform.sizeDelta = Vector2.one * (40 + EaseUtils.FromZero(80, ease1));
                 SongBurstSubImage1.rectTransform.sizeDelta
-                    = SongBurstSubImage2.rectTransform.sizeDelta = Vector2.one * (120 * ease1);
+                    = SongBurstSubImage2.rectTransform.sizeDelta = Vector2.one * EaseUtils.FromZero(120, ease1);
 
-                float ease2 = Ease.Get(t, EaseFunction.Quadratic, EaseMode.In);
-                SongBurstGroup.alpha = 1 - ease2;
+                SongBurstGroup.alpha = EaseUtils.ToZero(1, t, EaseFunction.Quadratic, EaseMode.In);
 
                 float ease3 = Ease.Get(t, EaseFunction.Exponential, EaseMode.Out);
                 SongBurstSubImage1.rectTransform.localEulerAngles
-                    = -(SongBurstSubImage2.rectTransform.localEulerAngles = Vector3.forward * (10 * ease3));
+                    = -(SongBurstSubImage2.rectTransform.localEulerAngles = Vector3.forward * EaseUtils.FromZero(10, ease3));
             });
         }
 
@@ -826,16 +824,14 @@ namespace JANOARG.Client.Behaviors.SongSelect
 
             SetScoreInfo(target);
 
-            StartCoroutine(Ease.Animate(.1f, a => {
-                float lerp = Ease.Get(a, EaseFunction.Cubic, EaseMode.Out);
+            StartCoroutine(Ease.Animate(.1f, EaseFunction.Cubic, EaseMode.Out, lerp => {
                 oldTarget.SetSelectability(1 - lerp);
                 target.SetSelectability(lerp);
-                rt(oldTarget.Holder).anchoredPosition = new(0, 5 * (1 - lerp));
+                rt(oldTarget.Holder).anchoredPosition = new(0, EaseUtils.ToZero(5, lerp));
             }));
-            yield return Ease.Animate(.15f, a => {
-                float lerp = Ease.Get(a, EaseFunction.Cubic, EaseMode.Out);
-                rt(target.Holder).anchoredPosition = new(0, 7 - 2 * lerp);
-                rt(target.Holder).localEulerAngles = 10 * (1 - lerp) * Vector3.back;
+            yield return Ease.Animate(.15f, EaseFunction.Cubic, EaseMode.Out, lerp => {
+                rt(target.Holder).anchoredPosition = new(0, 7 - EaseUtils.FromZero(2, lerp));
+                rt(target.Holder).localEulerAngles = EaseUtils.ToZero(10, lerp) * Vector3.back;
             });
             IsAnimating = false;
 
@@ -843,15 +839,13 @@ namespace JANOARG.Client.Behaviors.SongSelect
 
         IEnumerator NavUpdateAnim()
         {
-            yield return Ease.Animate(0.2f, (x) =>
+            yield return Ease.Animate(0.2f, EaseFunction.Cubic, EaseMode.Out, ease1 =>
             {
-                float ease1 = Ease.Get(x, EaseFunction.Cubic, EaseMode.Out);
                 LerpActions(1 - ease1);
             });
             UpdateButtons();
-            yield return Ease.Animate(0.2f, (x) =>
+            yield return Ease.Animate(0.2f, EaseFunction.Cubic, EaseMode.Out, ease1 =>
             {
-                float ease1 = Ease.Get(x, EaseFunction.Cubic, EaseMode.Out);
                 LerpActions(ease1);
             });
         }
@@ -985,7 +979,7 @@ namespace JANOARG.Client.Behaviors.SongSelect
                 float lerp3 = Mathf.Pow(Ease.Get(a, EaseFunction.Exponential, EaseMode.Out), 0.5f);
                 rt(LaunchTextHolder).sizeDelta = new(LaunchText.preferredWidth * lerp3, rt(LaunchTextHolder).sizeDelta.y);
                 LaunchTextHolder.alpha = Random.Range(1, 2f) - lerp2 * 2;
-                TargetSongCoverFlash.color = new(1, 1, 1, 1 - lerp3);
+                TargetSongCoverFlash.color = new(1, 1, 1, EaseUtils.ToZero(1, lerp3));
             
 
                 float lerp4 = Ease.Get(a, EaseFunction.Cubic, EaseMode.Out);
@@ -1272,9 +1266,8 @@ namespace JANOARG.Client.Behaviors.SongSelect
 
         IEnumerator IntroShowMapUIAnim()
         {
-            yield return Ease.Animate(.2f, (x) =>
+            yield return Ease.Animate(.2f, EaseFunction.Cubic, EaseMode.Out, ease1 =>
             {
-                float ease1 = Ease.Get(x, EaseFunction.Cubic, EaseMode.Out);
                 LerpActions(ease1);
                 ProfileBar.sMain.SetVisibility(ease1);
             });

--- a/Assets/JANOARG.Client/Scripts/Behaviors/SongSelect/SongSelectScreen.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/SongSelect/SongSelectScreen.cs
@@ -1132,8 +1132,9 @@ namespace JANOARG.Client.Behaviors.SongSelect
         {
             Transform cameraTransform = CommonSys.sMain.MainCamera.transform;
 
-            yield return Ease.Animate(0.6f, (t) =>
+            yield return Ease.Animate(0.6f, (Action<float>)((t) =>
             {
+                float lerp1 = Ease.Get(t, EaseFunction.Exponential, EaseMode.In);
                 cameraTransform.position =
                     Vector3.Lerp(cameraTransform.position, target.position, 1 - Mathf.Pow(1e-3f, Time.deltaTime)) 
                     * new Vector3Frag(z: -10 * EaseUtils.ToZero(1, t, EaseFunction.Exponential, EaseMode.In));
@@ -1150,7 +1151,7 @@ namespace JANOARG.Client.Behaviors.SongSelect
                     // There's no cases where LeaveInAnim is called in list view yet
                     throw new NotImplementedException();
                 }
-            });
+            }));
         }
 
         /// <summary>

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Storyteller/Storyteller.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Storyteller/Storyteller.cs
@@ -219,8 +219,8 @@ namespace JANOARG.Client.Behaviors.Storyteller
             _CurrentNameFieldRoutine = Ease.EnumAnimate(0.2f, x =>
             {
                 float ease = Ease.Get(x, EaseFunction.Quadratic, EaseMode.Out);
-                NameLabelGroup.alpha = Mathf.Lerp(fromAlpha, toAlpha, ease);
-                float xPos = Mathf.Lerp(fromXPos, toXPos, ease);
+                NameLabelGroup.alpha = EaseUtils.LerpTo(fromAlpha, toAlpha, ease);
+                float xPos = EaseUtils.LerpTo(fromXPos, toXPos, ease);
                 NameLabelHolder.anchorMin = NameLabelHolder.anchorMax = NameLabelHolder.pivot = new Vector2(xPos, 0.5f);
                 NameLabelHolder.anchoredPosition = new Vector2(0, (1 - NameLabelGroup.alpha) * -5);
             });

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Storyteller/Storyteller.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Storyteller/Storyteller.cs
@@ -107,8 +107,7 @@ namespace JANOARG.Client.Behaviors.Storyteller
                 float ease = Ease.Get(x, EaseFunction.Quadratic, EaseMode.Out);
                 DialogueLabel.color = new Color(1, 1, 1, 1 - ease);
 
-                float ease2 = Ease.Get(x, EaseFunction.Cubic, EaseMode.In);
-                DialogueLabel.rectTransform.anchoredPosition = dialoguePos + ease2 * 5 * Vector2.down;
+                DialogueLabel.rectTransform.anchoredPosition = dialoguePos + EaseUtils.FromZero(5, x, EaseFunction.Cubic, EaseMode.In) * Vector2.down;
             });
 
             DialogueLabel.text = "";
@@ -190,9 +189,8 @@ namespace JANOARG.Client.Behaviors.Storyteller
             {
                 x = Mathf.Lerp(_CurrentNextChunkIndicatorPosition, target, x);
                 _CurrentNextChunkIndicatorPosition = x;
-                float ease = Ease.Get(x, EaseFunction.Cubic, EaseMode.Out);
                 NextChunkIndicator.color = new Color(1, 1, 1, x);
-                NextChunkIndicator.rectTransform.anchoredPosition = 5 * (1 - ease) * Vector2.down;
+                NextChunkIndicator.rectTransform.anchoredPosition = 5 * EaseUtils.ToZero(1, x, EaseFunction.Cubic, EaseMode.Out) * Vector2.down;
             });
             StartCoroutine(_CurrentNextChunkIndicatorRoutine);
         }

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Storyteller/Storyteller.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Storyteller/Storyteller.cs
@@ -180,39 +180,29 @@ namespace JANOARG.Client.Behaviors.Storyteller
             StartCoroutine(f_registration());
         }
 
-        private float     _CurrentNextChunkIndicatorPosition = 0;
-        private Coroutine _CurrentNextChunkIndicatorRoutine  = null;
+        private float          _CurrentNextChunkIndicatorPosition = 0;
+        private EaseEnumerator _CurrentNextChunkIndicatorRoutine  = null;
 
         public void SetNextChunkIndicatorState(float target)
         {
-            if (_CurrentNextChunkIndicatorRoutine != null) StopCoroutine(_CurrentNextChunkIndicatorRoutine);
-            _CurrentNextChunkIndicatorRoutine = StartCoroutine(NextChunkIndicatorAnim(target));
-        }
-
-        private IEnumerator NextChunkIndicatorAnim(float target)
-        {
-            float from = _CurrentNextChunkIndicatorPosition;
-
-            yield return Ease.Animate(0.2f, (x) =>
+            _CurrentNextChunkIndicatorRoutine?.Skip();
+            _CurrentNextChunkIndicatorRoutine = Ease.EnumAnimate(0.2f, x =>
             {
-                x = Mathf.Lerp(from, target, x);
+                x = Mathf.Lerp(_CurrentNextChunkIndicatorPosition, target, x);
                 _CurrentNextChunkIndicatorPosition = x;
                 float ease = Ease.Get(x, EaseFunction.Cubic, EaseMode.Out);
                 NextChunkIndicator.color = new Color(1, 1, 1, x);
                 NextChunkIndicator.rectTransform.anchoredPosition = 5 * (1 - ease) * Vector2.down;
             });
+            StartCoroutine(_CurrentNextChunkIndicatorRoutine);
         }
 
-        private Coroutine _CurrentNameFieldRoutine = null;
+        private EaseEnumerator _CurrentNameFieldRoutine = null;
 
         public void SetNameLabelText(string label)
         {
-            if (_CurrentNameFieldRoutine != null) StopCoroutine(_CurrentNameFieldRoutine);
-            _CurrentNameFieldRoutine = StartCoroutine(NameLabelAnim(label));
-        }
+            _CurrentNameFieldRoutine?.Skip();
 
-        private IEnumerator NameLabelAnim(string label)
-        {
             float fromAlpha = NameLabelGroup.alpha;
             float toAlpha = string.IsNullOrWhiteSpace(label) ? 0 : 1;
             float fromXPos = NameLabelHolder.anchorMin.x;
@@ -226,7 +216,7 @@ namespace JANOARG.Client.Behaviors.Storyteller
 
             if (fromAlpha == 0) fromXPos = toXPos;
 
-            yield return Ease.Animate(0.2f, (x) =>
+            _CurrentNameFieldRoutine = Ease.EnumAnimate(0.2f, x =>
             {
                 float ease = Ease.Get(x, EaseFunction.Quadratic, EaseMode.Out);
                 NameLabelGroup.alpha = Mathf.Lerp(fromAlpha, toAlpha, ease);
@@ -234,6 +224,7 @@ namespace JANOARG.Client.Behaviors.Storyteller
                 NameLabelHolder.anchorMin = NameLabelHolder.anchorMax = NameLabelHolder.pivot = new Vector2(xPos, 0.5f);
                 NameLabelHolder.anchoredPosition = new Vector2(0, (1 - NameLabelGroup.alpha) * -5);
             });
+            StartCoroutine(_CurrentNameFieldRoutine);
         }
     }
 }

--- a/Assets/JANOARG.Client/Scripts/UI/AnimatedToggle.cs
+++ b/Assets/JANOARG.Client/Scripts/UI/AnimatedToggle.cs
@@ -49,7 +49,7 @@ namespace JANOARG.Client.UI
             _ProgressFrom = _Progress;
             _Routine = Ease.EnumAnimate(0.2f, EaseFunction.Cubic, EaseMode.Out, ease =>
             {
-                SetToggleEase(Mathf.Lerp(_ProgressFrom, _Value ? 1 : 0, ease));
+                SetToggleEase(EaseUtils.LerpTo(_ProgressFrom, _Value ? 1 : 0, ease));
             });
             StartCoroutine(_Routine);
             OnValueChanged.Invoke(_Value);

--- a/Assets/JANOARG.Client/Scripts/UI/AnimatedToggle.cs
+++ b/Assets/JANOARG.Client/Scripts/UI/AnimatedToggle.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using JANOARG.Shared.Data.ChartInfo;
 using UnityEngine;
 using UnityEngine.Events;
@@ -26,7 +25,7 @@ namespace JANOARG.Client.UI
             set
             {
                 _Value = value;
-                if (_Routine != null) StopCoroutine(_Routine);
+                _Routine?.Skip();
                 SetToggleEase(_Value ? 1 : 0);
             }
         }
@@ -46,26 +45,19 @@ namespace JANOARG.Client.UI
         public void Toggle()
         {
             _Value = !_Value;
-            if (_Routine != null) StopCoroutine(_Routine);
-            _Routine = StartCoroutine(ToggleAnim(_Value ? 1 : 0));
+            _Routine?.Skip();
+            _ProgressFrom = _Progress;
+            _Routine = Ease.EnumAnimate(0.2f, EaseFunction.Cubic, EaseMode.Out, ease =>
+            {
+                SetToggleEase(Mathf.Lerp(_ProgressFrom, _Value ? 1 : 0, ease));
+            });
+            StartCoroutine(_Routine);
             OnValueChanged.Invoke(_Value);
         }
 
-        private float     _Progress;
-        private Coroutine _Routine;
-
-        public IEnumerator ToggleAnim(float to)
-        {
-            float from = _Progress;
-
-            yield return Ease.Animate(0.2f, x =>
-            {
-                float ease = Ease.Get(x, EaseFunction.Cubic, EaseMode.Out);
-                SetToggleEase(Mathf.Lerp(from, to, ease));
-            });
-
-            _Routine = null;
-        }
+        private float          _Progress;
+        private float          _ProgressFrom;
+        private EaseEnumerator _Routine;
 
         public void SetToggleEase(float ease)
         {

--- a/Assets/JANOARG.Client/Scripts/UI/Modal/Modal.cs
+++ b/Assets/JANOARG.Client/Scripts/UI/Modal/Modal.cs
@@ -60,9 +60,9 @@ namespace JANOARG.Client.UI.Modal
             ColorBackground.color = CommonSys.sMain.MainCamera.backgroundColor;
 
             // Button
-            var buttonRoutine = StartCoroutine(Ease.Animate(0.3f, (t) =>
+            var buttonRoutine = StartCoroutine(Ease.Animate(0.3f, EaseFunction.Cubic, EaseMode.Out, (t) =>
             {
-                SetButtonVisibility(Ease.Get(t, EaseFunction.Cubic, EaseMode.Out));
+                SetButtonVisibility(t);
             }));
 
             yield return Ease.Animate(0.8f, (t) =>
@@ -80,7 +80,7 @@ namespace JANOARG.Client.UI.Modal
                 InnerBodyBackground.anchorMin *= new Vector2Frag(y: .5f - .5f * ease2);
                 InnerBodyBackground.anchorMax *= new Vector2Frag(y: .5f + .5f * ease2);
                 float ease3 = Ease.Get(t, EaseFunction.Exponential, EaseMode.Out);
-                BodyHolder.anchoredPosition *= new Vector2Frag(x: 150 * (1 - ease3));
+                BodyHolder.anchoredPosition *= new Vector2Frag(x: EaseUtils.ToZero(150, ease3));
             });
 
             yield return buttonRoutine;
@@ -92,9 +92,9 @@ namespace JANOARG.Client.UI.Modal
         {
 
             // Button
-            var buttonRoutine = StartCoroutine(Ease.Animate(0.3f, (t) =>
+            var buttonRoutine = StartCoroutine(Ease.Animate(0.3f, EaseFunction.Cubic, EaseMode.Out, (t) =>
             {
-                SetButtonVisibility(1 - Ease.Get(t, EaseFunction.Cubic, EaseMode.Out));
+                SetButtonVisibility(1 - t);
             }));
 
             
@@ -115,7 +115,7 @@ namespace JANOARG.Client.UI.Modal
                 InnerBodyBackground.anchorMin *= new Vector2Frag(y: .5f * ease2);
                 InnerBodyBackground.anchorMax *= new Vector2Frag(y: 1 - .5f * ease2);
                 float ease3 = Ease.Get(t, EaseFunction.Exponential, EaseMode.In);
-                BodyHolder.anchoredPosition *= new Vector2Frag(x: -1000 * ease3);
+                BodyHolder.anchoredPosition *= new Vector2Frag(x: EaseUtils.FromZero(-1000, ease3));
             });
 
             yield return buttonRoutine;

--- a/Assets/JANOARG.Client/Scripts/UI/Sidebar.cs
+++ b/Assets/JANOARG.Client/Scripts/UI/Sidebar.cs
@@ -23,21 +23,10 @@ namespace JANOARG.Client.UI
             isAnimating = true;
             var rt = GetComponent<RectTransform>();
 
-            void f_lerpContent(float value)
+            yield return Ease.Animate(.4f, EaseFunction.Quartic, EaseMode.Out, ease =>
             {
-                float ease = Ease.Get(value, EaseFunction.Quartic, EaseMode.Out);
-
                 rt.anchoredPosition = Vector3.left * (2000 + (Width - SafeArea.sizeDelta.y / 2) * (1 - ease));
-            }
-
-            for (float a = 0; a < 1; a += Time.deltaTime / .4f)
-            {
-                f_lerpContent(a);
-
-                yield return null;
-            }
-
-            f_lerpContent(1);
+            });
 
             isAnimating = false;
         }
@@ -52,21 +41,10 @@ namespace JANOARG.Client.UI
             isAnimating = true;
             var rt = GetComponent<RectTransform>();
 
-            void f_lerpContent(float value)
+            yield return Ease.Animate(.3f, EaseFunction.Quartic, EaseMode.In, ease =>
             {
-                float ease = Ease.Get(value, EaseFunction.Quartic, EaseMode.In);
-
                 rt.anchoredPosition = Vector3.left * (2000 + (Width - SafeArea.sizeDelta.y / 2) * ease);
-            }
-
-            for (float a = 0; a < 1; a += Time.deltaTime / .3f)
-            {
-                f_lerpContent(a);
-
-                yield return null;
-            }
-
-            f_lerpContent(1);
+            });
 
             if (SetActiveOnHide) gameObject.SetActive(false);
 

--- a/Assets/JANOARG.Client/Scripts/UI/TabbedSidebar.cs
+++ b/Assets/JANOARG.Client/Scripts/UI/TabbedSidebar.cs
@@ -93,8 +93,8 @@ namespace JANOARG.Client.UI
                 float ease = Ease.Get(value / .75f, EaseFunction.Cubic, EaseMode.Out);
                 float ease2 = Ease.Get((value - .25f) / .75f, EaseFunction.Cubic, EaseMode.Out);
 
-                float min = Mathf.Lerp(oldRT.anchoredPosition.y, newRT.anchoredPosition.y, oldIndex > index ? ease2 : ease);
-                float max = Mathf.Lerp(oldRT.anchoredPosition.y, newRT.anchoredPosition.y, oldIndex < index ? ease2 : ease);
+                float min = EaseUtils.LerpTo(oldRT.anchoredPosition.y, newRT.anchoredPosition.y, oldIndex > index ? ease2 : ease);
+                float max = EaseUtils.LerpTo(oldRT.anchoredPosition.y, newRT.anchoredPosition.y, oldIndex < index ? ease2 : ease);
 
                 TabButtonIndicator.anchoredPosition = Vector2.up * min;
                 TabButtonIndicator.sizeDelta = sizeDelta + Vector2.up * (max - min);
@@ -106,7 +106,7 @@ namespace JANOARG.Client.UI
 
                 TabGroup.alpha = value;
                 TabLabel.alpha = value / 2;
-                ScrollHolder.anchoredPosition = Vector3.left * 50 * (1 - ease);
+                ScrollHolder.anchoredPosition = Vector3.left * EaseUtils.ToZero(50, ease);
             }
 
             var isSet = false;


### PR DESCRIPTION
This PR is following the recent merge of Easing.cs major API and QoL(?) changes (https://github.com/FFF40/JANOARG.Shared/pull/3)

**Animation system (pass 1 & 2)**
(Done by Claude with monitoring)

Replaces manual `Coroutine` stop/restart patterns with `EaseEnumerator` from the updated easing library, enabling per-animation `Skip()` control and `IsComplete` tracking across `AnimatedToggle`, `AudioManager`, `Storyteller`, `SongSelectFilterPanel`, `SongSelectListView`, `OptionCalibrationWizard`, and `ProfileBar`.

Follows up with a simplification pass across 19 files replacing `float ease = Ease.Get(...); N * ease` patterns with `EaseUtils.FromZero`/`ToZero`/`LerpTo` helpers and the new eased `Ease.Animate` overloads that pre-calculate the ease value, removing intermediate variables and reducing noise in animation callbacks.


Hit rendering performance (Side changes :v)

Adds independent `Canvas` components with `Override Sorting` to `Judge Screen Pool`, `Judge Screen`, and frequently-updated HUD elements (score, combo, judgment). This isolates their per-frame dirty marks from the main canvas, preventing `Graphic.Rebuild()` and `TextMeshProUGUI.Rebuild()` from cascading across the full HUD on every hit.