### PR TITLE
Fix headless mode Player initialisation

### DIFF
--- a/Assets/JANOARG.Client/Scripts/Behaviors/Common/Common.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Common/Common.cs
@@ -57,7 +57,8 @@ namespace JANOARG.Client.Behaviors.Common
         {
             yield return SceneManager.LoadSceneAsync(target, LoadSceneMode.Additive);
             yield return Resources.UnloadUnusedAssets();
-            yield return new WaitUntil(completed);
+            if (completed != null)
+                yield return new WaitUntil(completed);
 
             if (onComplete != null) onComplete();
         }

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Player/HeadlessPlayerStarter.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Player/HeadlessPlayerStarter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.IO;
 using JANOARG.Client.Behaviors.Common;
 using JANOARG.Shared.Data.ChartInfo;
@@ -17,7 +18,7 @@ namespace JANOARG.Client.Behaviors.Player
         private static PlayableSong      s_targetSong;
         private static ExternalChartMeta s_targetChartMeta;
 
-        public void Start()
+        public IEnumerator Start()
         {
             // Start check
             if (sRunChart == null || sChart == null)
@@ -25,8 +26,13 @@ namespace JANOARG.Client.Behaviors.Player
                     "RunChart or Chart must be assigned! Assign it from the editor in the PlayerScreen component AND enter playmode from there.");
 
 #if UNITY_EDITOR
+            s_targetSong = null;
+            s_targetSongPath = null;
+            s_targetChartMeta = null;
+
             // Prepare variables
             string runChartPath = AssetDatabase.GetAssetPath(sRunChart);
+            string chartPath = AssetDatabase.GetAssetPath(sChart);
 
             string directory = Path.Combine( // Get the last 2 directories in the path
                 Path.GetFileName(
@@ -42,17 +48,20 @@ namespace JANOARG.Client.Behaviors.Player
 
             Debug.LogWarning("TargetSong is null, Loading RunChart from " + runChartPath);
 
-            int attempt = 0;
-            while (s_targetSong == null || s_targetChartMeta == null || s_targetSongPath == null)
-            {
-                Debug.LogWarning($"Attempting to load datas ({attempt})");
-                attempt++;
-                if (attempt > 20)
-                    throw new Exception("Failed to load datas");
-                s_targetSong = sRunChart.Data;
-                s_targetSongPath = Path.Combine(directory, Path.GetFileNameWithoutExtension(runChartPath));
-                s_targetChartMeta = s_targetSong.Charts.Find(meta => meta.DifficultyName == sChart.Data.DifficultyName);
-            }
+            s_targetSong = sRunChart.Data;
+            s_targetSongPath = Path.Combine(directory, Path.GetFileNameWithoutExtension(runChartPath));
+            string chartTarget = Path.GetFileNameWithoutExtension(chartPath);
+            s_targetChartMeta = s_targetSong.Charts.Find(meta =>
+                meta.Target == chartTarget || meta.Target == Path.GetFileName(chartPath));
+
+            if (s_targetSong == null)
+                throw new Exception($"Failed to load song data from '{runChartPath}'.");
+
+            if (string.IsNullOrEmpty(s_targetSongPath))
+                throw new Exception($"Failed to build a Resources path for '{runChartPath}'.");
+
+            if (s_targetChartMeta == null)
+                throw new Exception($"Failed to find chart metadata targeting '{chartTarget}' in '{runChartPath}'.");
 #endif
 
             // Prepare scene
@@ -62,13 +71,22 @@ namespace JANOARG.Client.Behaviors.Player
             PlayerScreen.sTargetSong = s_targetSong;
             PlayerScreen.sTargetSongPath = s_targetSongPath;
             PlayerScreen.sTargetChartMeta = s_targetChartMeta;
+            PlayerScreen.sTargetChart = sChart;
+            PlayerScreen.sMain = null;
+
+            yield return new WaitUntil(() => !SceneManager.GetSceneByName("Player").isLoaded);
+            yield return null;
+            yield return new WaitForEndOfFrame();
+            yield return null;
 
             CommonSys.Load(
                 "Player", () => PlayerScreen.sMain && PlayerScreen.sMain.IsReady,
-                () => { PlayerScreen.sMain.BeginReadyAnim(); });
-
-            SceneManager.UnloadSceneAsync("HeadlessPlayerStarter");
-            Resources.UnloadUnusedAssets();
+                () =>
+                {
+                    PlayerScreen.sMain.BeginReadyAnim();
+                    SceneManager.UnloadSceneAsync("HeadlessPlayerStarter");
+                    Resources.UnloadUnusedAssets();
+                });
         }
     }
 }

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Player/PlayerScreen.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Player/PlayerScreen.cs
@@ -184,6 +184,12 @@ namespace JANOARG.Client.Behaviors.Player
             CommonScene.Load();
         }
 
+        public void OnDestroy()
+        {
+            if (sMain == this)
+                sMain = null;
+        }
+
         public void Start()
         {
             InitFlickMeshes();
@@ -224,6 +230,9 @@ namespace JANOARG.Client.Behaviors.Player
             }
             else
             {
+                if (sTargetChartMeta == null)
+                    throw new InvalidOperationException("Target chart metadata is missing before chart load.");
+
                 SongNameLabel.text = sTargetSong.SongName;
                 SongArtistLabel.text = sTargetSong.SongArtist;
 
@@ -237,18 +246,37 @@ namespace JANOARG.Client.Behaviors.Player
                     // SongSelectReadyScreen.sMain.CurrentProgress.text = "Loading audio file...";
                 }
 
-                string path = Path.Combine(Path.GetDirectoryName(sTargetSongPath)!, sTargetChartMeta.Target);
-                Debug.Log(path);
-                ResourceRequest chartLoadRequest = Resources.LoadAsync<ExternalChart>(path);
+                if (sTargetSong.Clip == null)
+                    throw new InvalidOperationException($"Target song '{sTargetSong.SongName}' is missing its audio clip.");
 
                 sTargetSong.Clip.LoadAudioData();
 
-                yield return new WaitUntil(() => chartLoadRequest.isDone && sTargetSong.Clip.loadState != AudioDataLoadState.Loading);
+                if (sHeadlessInitialised && sTargetChart != null)
+                {
+                    yield return new WaitUntil(() => sTargetSong.Clip.loadState != AudioDataLoadState.Loading);
+                }
+                else
+                {
+                    string path = Path.Combine(Path.GetDirectoryName(sTargetSongPath)!, sTargetChartMeta.Target);
+                    Debug.Log(path);
+                    ResourceRequest chartLoadRequest = Resources.LoadAsync<ExternalChart>(path);
+
+                    yield return new WaitUntil(() => chartLoadRequest.isDone && sTargetSong.Clip.loadState != AudioDataLoadState.Loading);
+
+                    sTargetChart = chartLoadRequest.asset as ExternalChart;
+
+                    if (sTargetChart == null)
+                        throw new InvalidOperationException($"Failed to load chart asset at Resources path '{path}'.");
+                }
 
                 if (!sHeadlessInitialised)
                     // SongSelectReadyScreen.sMain.CurrentProgress.text += "Done.";
 
-                sTargetChart = chartLoadRequest.asset as ExternalChart;
+                if (sHeadlessInitialised)
+                {
+                    yield return null;
+                    yield return new WaitForEndOfFrame();
+                }
 
                 yield return InitChart();
             }

--- a/Assets/JANOARG.Client/Scripts/Behaviors/Player/PlayerScreen.cs
+++ b/Assets/JANOARG.Client/Scripts/Behaviors/Player/PlayerScreen.cs
@@ -31,7 +31,6 @@ namespace JANOARG.Client.Behaviors.Player
 
         public static Chart sCurrentChart;
 
-        [Header("Headless Initialisation")]
         public ExternalPlayableSong RunChart;
 
         public ExternalChart Chart;

--- a/Assets/JANOARG.Client/Scripts/Editor/PlayerScreenEditor.cs
+++ b/Assets/JANOARG.Client/Scripts/Editor/PlayerScreenEditor.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using JANOARG.Client.Behaviors.Player;
+using JANOARG.Shared.Data.ChartInfo;
+using UnityEditor;
+using UnityEngine;
+
+namespace JANOARG.Client.Editor
+{
+    [CustomEditor(typeof(PlayerScreen))]
+    internal class PlayerScreenEditor : UnityEditor.Editor
+    {
+        private SerializedProperty _RunChart;
+        private SerializedProperty _Chart;
+
+        private void OnEnable()
+        {
+            _RunChart = serializedObject.FindProperty("RunChart");
+            _Chart = serializedObject.FindProperty("Chart");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+
+            using (new EditorGUI.DisabledScope(true))
+                EditorGUILayout.ObjectField("Script", MonoScript.FromMonoBehaviour((PlayerScreen)target), typeof(PlayerScreen), false);
+
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField("Headless Initialisation", EditorStyles.boldLabel);
+            EditorGUILayout.PropertyField(_RunChart);
+
+            DrawChartSelector();
+
+            EditorGUILayout.Space();
+            DrawPropertiesExcluding(serializedObject, "m_Script", "RunChart", "Chart");
+
+            serializedObject.ApplyModifiedProperties();
+        }
+
+        private void DrawChartSelector()
+        {
+            ExternalPlayableSong runChart = _RunChart.objectReferenceValue as ExternalPlayableSong;
+            if (runChart == null)
+            {
+                if (_Chart.objectReferenceValue != null)
+                    _Chart.objectReferenceValue = null;
+
+                EditorGUILayout.HelpBox("Assign Run Chart to choose a chart from the same source folder.", MessageType.Info);
+                return;
+            }
+
+            string runChartPath = AssetDatabase.GetAssetPath(runChart);
+            string folderPath = Path.GetDirectoryName(runChartPath);
+
+            if (string.IsNullOrEmpty(folderPath))
+            {
+                EditorGUILayout.HelpBox("Couldn't resolve the Run Chart asset folder.", MessageType.Warning);
+                return;
+            }
+
+            List<ExternalChart> charts = AssetDatabase.FindAssets("t:ExternalChart", new[] { folderPath })
+                .Select(AssetDatabase.GUIDToAssetPath)
+                .Where(path => Path.GetDirectoryName(path) == folderPath)
+                .Select(AssetDatabase.LoadAssetAtPath<ExternalChart>)
+                .Where(chart => chart != null)
+                .OrderBy(chart => chart.name)
+                .ToList();
+
+            if (charts.Count == 0)
+            {
+                if (_Chart.objectReferenceValue != null)
+                    _Chart.objectReferenceValue = null;
+
+                EditorGUILayout.HelpBox($"No ExternalChart assets were found beside '{runChart.name}'.", MessageType.Warning);
+                return;
+            }
+
+            ExternalChart selectedChart = _Chart.objectReferenceValue as ExternalChart;
+            if (selectedChart != null && !charts.Contains(selectedChart))
+            {
+                selectedChart = null;
+                _Chart.objectReferenceValue = null;
+            }
+
+            string[] options = charts
+                .Select(chart => $"{chart.name} ({Path.GetFileName(AssetDatabase.GetAssetPath(chart))})")
+                .ToArray();
+
+            int currentIndex = Mathf.Max(0, selectedChart == null ? 0 : charts.IndexOf(selectedChart));
+            int nextIndex = EditorGUILayout.Popup("Chart", currentIndex, options);
+
+            _Chart.objectReferenceValue = charts[nextIndex];
+
+            using (new EditorGUI.DisabledScope(true))
+                EditorGUILayout.ObjectField("Selected Chart", _Chart.objectReferenceValue, typeof(ExternalChart), false);
+        }
+    }
+}

--- a/Assets/JANOARG.Client/Scripts/Editor/PlayerScreenEditor.cs.meta
+++ b/Assets/JANOARG.Client/Scripts/Editor/PlayerScreenEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0f8d65864470422f9d53c31c1b9cf554
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR fixes headless chart loading in PlayerScreen and improves the authoring flow for the headless RunChart / Chart fields in the inspector.

  Headless play was failing intermittently because the bootstrap path relied on fragile chart reloading and timing-sensitive scene handoff between the old and new Player scenes. This change makes that flow more deterministic and
  also makes the editor-side setup much harder to misconfigure.

  What changed

  - Guard CommonSys.Load(...) against null completion callbacks.
  - Add a custom PlayerScreen inspector for headless setup:
      - hide Chart until RunChart is assigned
      - limit chart selection to ExternalChart assets in the same folder as the selected RunChart

None selected:
<img width="619" height="95" alt="image" src="https://github.com/user-attachments/assets/f58386a0-7727-43f7-a60c-a5c4f098eed2" />
    Chart difficulty selector:
<img width="619" height="107" alt="image" src="https://github.com/user-attachments/assets/915ad4c7-568c-40ac-83c1-6a01517b6d52" />
    Chart properly selected:
<img width="619" height="107" alt="image" src="https://github.com/user-attachments/assets/3326d7aa-b886-4c1d-8be3-9ff26da26265" />

  - Harden HeadlessPlayerStarter:
      - rebuild delegated song/chart metadata from the selected assets
      - match chart metadata by resource target
      - pass the selected ExternalChart directly into the fresh Player bootstrap
      - clear stale PlayerScreen.sMain
      - wait for the old Player scene to unload before loading the fresh one
      - defer unloading HeadlessPlayerStarter until the new Player is ready
  - Update PlayerScreen headless loading:
      - validate delegated metadata and audio clip before continuing
      - skip Resources.LoadAsync<ExternalChart> when headless already has the selected chart asset
      - add small headless-only frame pacing before InitChart() to avoid the scene-handoff race
      - clear PlayerScreen.sMain in OnDestroy()

  Why
  Before this PR, headless mode could:

  - fail to find chart metadata because of filename vs resource-target mismatch
  - fail to resolve the chart again through Resources
  - stall during the old Player -> HeadlessPlayerStarter -> fresh Player handoff
  - allow easy inspector misconfiguration by exposing unrelated chart assets
  
  ...basically unstable as shiet